### PR TITLE
++copy/pipeline.hh Memory::Copy2D

### DIFF
--- a/include/blade/memory/devices/cuda/copy.hh
+++ b/include/blade/memory/devices/cuda/copy.hh
@@ -47,6 +47,101 @@ static Result Copy(Vector<Device::CPU, T>& dst,
     return Memory::Copy(dst, src, cudaMemcpyDeviceToHost, stream);
 }
 
+template<typename DT, typename ST>
+static Result Copy2D(VectorImpl<DT>& dst,
+                   const size_t dpitch,
+                   const VectorImpl<ST>& src,
+                   const size_t spitch,
+                   const size_t width,
+                   const size_t height,
+                   const cudaMemcpyKind& kind,
+                   const cudaStream_t& stream = 0) {
+    auto failure = false;
+    if (width > dpitch) {
+        BL_FATAL("2D copy 'width' is larger than destination's pitch ({}, {}).",
+                width, dpitch);
+        failure = true;
+    }
+    if (dst.size_bytes() != dpitch*height) {
+        BL_FATAL("Destination's size is not exactly covered by {} rows of {} ({} vs {}).",
+                height, dpitch, dst.size_bytes(), dpitch*height);
+        failure = true;
+    }
+    if (width > spitch) {
+        BL_FATAL("2D copy 'width' is larger than source's pitch ({}, {}).",
+                width, spitch);
+        failure = true;
+    }
+    if (src.size_bytes() != spitch*height) {
+        BL_FATAL("Source's size is not exactly covered by {} rows of {} ({} vs {}).",
+                height, spitch, src.size_bytes(), spitch*height);
+        failure = true;
+    }
+    if (width % sizeof(DT) != 0) {
+        BL_FATAL("2D copy 'width' is not a multiple of destination's element size ({}, {}).",
+                width, sizeof(DT));
+        failure = true;
+    }
+    if (width % sizeof(ST) != 0) {
+        BL_FATAL("2D copy 'width' is not a multiple of source's element size ({}, {}).",
+                width, sizeof(ST));
+        failure = true;
+    }
+    if (failure) {
+        return Result::ASSERTION_ERROR;
+    }
+
+    BL_CUDA_CHECK(
+        cudaMemcpy2DAsync(
+            dst.data(),
+            dpitch,
+            src.data(),
+            spitch,
+            width,
+            height,
+            kind, stream),
+        [&]{
+            BL_FATAL("Can't 2D copy data ({}): {}", kind, err);
+            return Result::CUDA_ERROR;
+        }
+    );
+
+    return Result::SUCCESS;
+}
+
+template<typename DT, typename ST>
+static Result Copy2D(Vector<Device::CUDA, DT>& dst,
+                   const size_t dpitch,
+                   const Vector<Device::CUDA, ST>& src,
+                   const size_t spitch,
+                   const size_t width,
+                   const size_t height,
+                   const cudaStream_t& stream = 0) {
+    return Memory::Copy2D(dst, dpitch, src, spitch, width, height, cudaMemcpyDeviceToDevice, stream);
+}
+
+template<typename DT, typename ST>
+static Result Copy2D(Vector<Device::CUDA, DT>& dst,
+                   const size_t dpitch,
+                   const Vector<Device::CPU, ST>& src,
+                   const size_t spitch,
+                   const size_t width,
+                   const size_t height,
+                   const cudaStream_t& stream = 0) {
+    return Memory::Copy2D(dst, dpitch, src, spitch, width, height, cudaMemcpyHostToDevice, stream);
+}
+
+template<typename DT, typename ST>
+static Result Copy2D(Vector<Device::CPU, DT>& dst,
+                   const size_t dpitch,
+                   const Vector<Device::CUDA, ST>& src,
+                   const size_t spitch,
+                   const size_t width,
+                   const size_t height,
+                   const cudaStream_t& stream = 0) {
+    return Memory::Copy2D(dst, dpitch, src, spitch, width, height, cudaMemcpyDeviceToHost, stream);
+}
+
 }  // namespace Blade::Memory
 
 #endif

--- a/include/blade/pipeline.hh
+++ b/include/blade/pipeline.hh
@@ -53,6 +53,46 @@ class BLADE_API Pipeline {
         return Memory::Copy(dst, src, this->stream);
     }
 
+    template<typename DT, typename ST>
+    Result copy2D(Vector<Device::CUDA, DT>& dst,
+                   const size_t dpitch,
+                   const Vector<Device::CUDA, ST>& src,
+                   const size_t spitch,
+                   const size_t width,
+                   const size_t height) {
+        return Memory::Copy2D(dst, dpitch, src, spitch, width, height, this->stream);
+    }
+
+    template<typename DT, typename ST>
+    Result copy2D(Vector<Device::CUDA, DT>& dst,
+                   const size_t dpitch,
+                   const Vector<Device::CPU, ST>& src,
+                   const size_t spitch,
+                   const size_t width,
+                   const size_t height) {
+        return Memory::Copy2D(dst, dpitch, src, spitch, width, height, this->stream);
+    }
+
+    template<typename DT, typename ST>
+    Result copy2D(Vector<Device::CPU, DT>& dst,
+                   const size_t dpitch,
+                   const Vector<Device::CPU, ST>& src,
+                   const size_t spitch,
+                   const size_t width,
+                   const size_t height) {
+        return Memory::Copy2D(dst, dpitch, src, spitch, width, height);
+    }
+
+    template<typename DT, typename ST>
+    Result copy2D(Vector<Device::CPU, DT>& dst,
+                   const size_t dpitch,
+                   const Vector<Device::CUDA, ST>& src,
+                   const size_t spitch,
+                   const size_t width,
+                   const size_t height) {
+        return Memory::Copy2D(dst, dpitch, src, spitch, width, height, this->stream);
+    }
+
  private:
     enum State : uint8_t {
         IDLE,


### PR DESCRIPTION
Adds interface to `cudaMemcpy2D`. This will enable greater flexibility in the output-D2H-copy for instance, particularly necessary for padding chunks so that network packet headers can be filled into the padding for network egress in a hashpipe  thread.