### PR TITLE
Polarizer module with phasor.

### DIFF
--- a/include/blade/memory/types.hh
+++ b/include/blade/memory/types.hh
@@ -61,6 +61,8 @@ struct BLADE_API TypeInfo<F16> {
     using subtype = F16;
     using surtype = CF16;
     inline static const std::string name = "F16";
+    inline static const std::size_t cudaSize = 1;
+    inline static const std::string cudaName = "__half";
 };
 
 template<>
@@ -69,6 +71,8 @@ struct BLADE_API TypeInfo<F32> {
     using subtype = F32;
     using surtype = CF32;
     inline static const std::string name = "F32";
+    inline static const std::size_t cudaSize = 1;
+    inline static const std::string cudaName = "float";
 };
 
 template<>
@@ -77,6 +81,8 @@ struct BLADE_API TypeInfo<F64> {
     using subtype = F64;
     using surtype = CF64;
     inline static const std::string name = "F64";
+    inline static const std::size_t cudaSize = 1;
+    inline static const std::string cudaName = "double";
 };
 
 template<>
@@ -85,6 +91,8 @@ struct BLADE_API TypeInfo<I8> {
     using subtype = I8;
     using surtype = CI8;
     inline static const std::string name = "I8";
+    inline static const std::size_t cudaSize = 1;
+    inline static const std::string cudaName = "signed char";
 };
 
 template<>
@@ -93,6 +101,8 @@ struct BLADE_API TypeInfo<I16> {
     using subtype = I16;
     using surtype = CI16;
     inline static const std::string name = "I16";
+    inline static const std::size_t cudaSize = 1;
+    inline static const std::string cudaName = "short";
 };
 
 template<>
@@ -101,6 +111,8 @@ struct BLADE_API TypeInfo<I32> {
     using subtype = I32;
     using surtype = CI32;
     inline static const std::string name = "I32";
+    inline static const std::size_t cudaSize = 1;
+    inline static const std::string cudaName = "long";
 };
 
 template<>
@@ -109,6 +121,8 @@ struct BLADE_API TypeInfo<I64> {
     using subtype = I64;
     using surtype = CI64;
     inline static const std::string name = "I64";
+    inline static const std::size_t cudaSize = 1;
+    inline static const std::string cudaName = "long long";
 };
 
 template<>
@@ -117,6 +131,8 @@ struct BLADE_API TypeInfo<U8> {
     using subtype = U8;
     using surtype = CU8;
     inline static const std::string name = "U8";
+    inline static const std::size_t cudaSize = 1;
+    inline static const std::string cudaName = "unsigned char";
 };
 
 template<>
@@ -125,6 +141,8 @@ struct BLADE_API TypeInfo<U16> {
     using subtype = U16;
     using surtype = CU16;
     inline static const std::string name = "U16";
+    inline static const std::size_t cudaSize = 1;
+    inline static const std::string cudaName = "unsigned short";
 };
 
 template<>
@@ -133,6 +151,8 @@ struct BLADE_API TypeInfo<U32> {
     using subtype = U32;
     using surtype = CU32;
     inline static const std::string name = "U32";
+    inline static const std::size_t cudaSize = 1;
+    inline static const std::string cudaName = "unsigned long";
 };
 
 template<>
@@ -141,6 +161,8 @@ struct BLADE_API TypeInfo<U64> {
     using subtype = U64;
     using surtype = CU64;
     inline static const std::string name = "U64";
+    inline static const std::size_t cudaSize = 1;
+    inline static const std::string cudaName = "unsigned long long";
 };
 
 template<>
@@ -149,6 +171,8 @@ struct BLADE_API TypeInfo<BOOL> {
     using subtype = BOOL;
     using surtype = BOOL;
     inline static const std::string name = "BOOL";
+    inline static const std::size_t cudaSize = 1;
+    inline static const std::string cudaName = "bool";
 };
 
 template<>
@@ -157,6 +181,8 @@ struct BLADE_API TypeInfo<CF16> {
     using subtype = F16;
     using surtype = F16;
     inline static const std::string name = "CF16";
+    inline static const std::size_t cudaSize = 2;
+    inline static const std::string cudaName = "half2";
 };
 
 template<>
@@ -165,6 +191,8 @@ struct BLADE_API TypeInfo<CF32> {
     using subtype = F32;
     using surtype = F32;
     inline static const std::string name = "CF32";
+    inline static const std::size_t cudaSize = 2;
+    inline static const std::string cudaName = "cuFloatComplex";
 };
 
 template<>
@@ -173,6 +201,8 @@ struct BLADE_API TypeInfo<CF64> {
     using subtype = F64;
     using surtype = F64;
     inline static const std::string name = "CF64";
+    inline static const std::size_t cudaSize = 2;
+    inline static const std::string cudaName = "cuDoubleComplex";
 };
 
 template<>
@@ -181,6 +211,8 @@ struct BLADE_API TypeInfo<CI8> {
     using subtype = I8;
     using surtype = I8;
     inline static const std::string name = "CI8";
+    inline static const std::size_t cudaSize = 2;
+    inline static const std::string cudaName = "NonSupported";
 };
 
 template<>
@@ -189,6 +221,8 @@ struct BLADE_API TypeInfo<CI16> {
     using subtype = I16;
     using surtype = I16;
     inline static const std::string name = "CI16";
+    inline static const std::size_t cudaSize = 2;
+    inline static const std::string cudaName = "NonSupported";
 };
 
 template<>
@@ -197,6 +231,8 @@ struct BLADE_API TypeInfo<CI32> {
     using subtype = I32;
     using surtype = I32;
     inline static const std::string name = "CI32";
+    inline static const std::size_t cudaSize = 2;
+    inline static const std::string cudaName = "NonSupported";
 };
 
 template<>
@@ -205,6 +241,8 @@ struct BLADE_API TypeInfo<CI64> {
     using subtype = I64;
     using surtype = I64;
     inline static const std::string name = "CI64";
+    inline static const std::size_t cudaSize = 2;
+    inline static const std::string cudaName = "NonSupported";
 };
 
 template<>
@@ -213,6 +251,8 @@ struct BLADE_API TypeInfo<CU8> {
     using subtype = U8;
     using surtype = U8;
     inline static const std::string name = "CU8";
+    inline static const std::size_t cudaSize = 2;
+    inline static const std::string cudaName = "NonSupported";
 };
 
 template<>
@@ -221,6 +261,8 @@ struct BLADE_API TypeInfo<CU16> {
     using subtype = U16;
     using surtype = U16;
     inline static const std::string name = "CU16";
+    inline static const std::size_t cudaSize = 2;
+    inline static const std::string cudaName = "NonSupported";
 };
 
 template<>
@@ -229,6 +271,8 @@ struct BLADE_API TypeInfo<CU32> {
     using subtype = U32;
     using surtype = U32;
     inline static const std::string name = "CU32";
+    inline static const std::size_t cudaSize = 2;
+    inline static const std::string cudaName = "NonSupported";
 };
 
 template<>
@@ -237,6 +281,8 @@ struct BLADE_API TypeInfo<CU64> {
     using subtype = U64;
     using surtype = U64;
     inline static const std::string name = "CU64";
+    inline static const std::size_t cudaSize = 2;
+    inline static const std::string cudaName = "NonSupported";
 };
 
 class Dimensions : public std::vector<U64> {

--- a/include/blade/module.hh
+++ b/include/blade/module.hh
@@ -73,52 +73,6 @@ class Module {
         return Result::SUCCESS;
     }
 
-    template<typename T>
-    static const std::string CudaType() {
-        static std::unordered_map<std::type_index, std::string> type_map = {
-            {typeid(CF16),  "__half"},
-            {typeid(CF32),  "float"},
-            {typeid(CI8),   "char"},
-            {typeid(CI16),  "short"},
-            {typeid(CI32),  "long"},
-            {typeid(F16),   "__half"},
-            {typeid(F32),   "float"},
-            {typeid(I8),    "char"},
-            {typeid(I16),   "short"},
-            {typeid(I32),   "long"},
-        };
-
-        auto& type = typeid(T);
-        if (!type_map.contains(type)) {
-            BL_FATAL("Type is not supported by CudaType.");
-            BL_CHECK_THROW(Result::ERROR);
-        }
-        return type_map[type];
-    }
-
-    template<typename T>
-    static const std::size_t CudaTypeSize() {
-        static std::unordered_map<std::type_index, std::size_t> size_map = {
-            {typeid(CF16),  2},
-            {typeid(CF32),  2},
-            {typeid(CI8),   2},
-            {typeid(CI16),  2},
-            {typeid(CI32),  2},
-            {typeid(F16),   1},
-            {typeid(F32),   1},
-            {typeid(I8),    1},
-            {typeid(I16),   1},
-            {typeid(I32),   1},
-        };
-
-        auto& type = typeid(T);
-        if (!size_map.contains(type)) {
-            BL_FATAL("Type is not supported by CudaTypeSize.");
-            BL_CHECK_THROW(Result::ERROR);
-        }
-        return size_map[type];
-    }
-
     static dim3 PadGridSize(const dim3& gridSize, const dim3& blockSize) {
         return dim3((gridSize.x + (blockSize.x - 1)) / blockSize.x,
                     (gridSize.y + (blockSize.y - 1)) / blockSize.y,

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
     'blade',
     ['cpp', 'c', 'cuda'],
-    version: '0.7.4',
+    version: '0.7.5',
     default_options: [
         'buildtype=release',
         'cpp_std=c++20',

--- a/src/modules/cast/base.cc
+++ b/src/modules/cast/base.cc
@@ -23,14 +23,14 @@ Cast<IT, OT>::Cast(const Config& config, const Input& input)
             "cast",
             // Kernel grid & block size.
             PadGridSize(
-                getInputBuffer().size() * CudaTypeSize<IT>(), 
+                getInputBuffer().size() * TypeInfo<IT>::cudaSize,
                 config.blockSize
             ),
             config.blockSize,
             // Kernel templates.
-            CudaType<IT>(),
-            CudaType<OT>(),
-            getInputBuffer().size() * CudaTypeSize<IT>()
+            TypeInfo<typename TypeInfo<IT>::subtype>::cudaName,
+            TypeInfo<typename TypeInfo<OT>::subtype>::cudaName,
+            getInputBuffer().size() * TypeInfo<IT>::cudaSize
         )
     );
 

--- a/src/modules/polarizer/base.cc
+++ b/src/modules/polarizer/base.cc
@@ -28,9 +28,9 @@ Polarizer<IT, OT>::Polarizer(const Config& config, const Input& input)
             ),
             config.blockSize,
             // Kernel templates.
-            CudaType<IT>(),
-            CudaType<OT>(),
-            getInputBuffer().size()
+            TypeInfo<IT>::cudaName,
+            TypeInfo<OT>::cudaName,
+            getInputBuffer().size() / 2
         )
     );
 
@@ -57,9 +57,6 @@ const Result Polarizer<IT, OT>::process(const cudaStream_t& stream) {
     return this->runKernel("main", stream, input.buf.data(), output.buf.data());
 }
 
-template class BLADE_API Polarizer<CI8, CI8>;
-template class BLADE_API Polarizer<CF16, CF16>;
 template class BLADE_API Polarizer<CF32, CF32>;
-template class BLADE_API Polarizer<CF64, CF64>;
 
 }  // namespace Blade::Modules

--- a/src/modules/polarizer/polarizer.cu
+++ b/src/modules/polarizer/polarizer.cu
@@ -9,7 +9,16 @@ __global__ void polarizer(const IT* input, OT* output) {
     if (tid < (N * 2)) {
         const IT& xPol = input[tid + 0];
         const OT& yPol = input[tid + 1];
-        output[tid + 0] = xPol + yPol;
-        output[tid + 1] = xPol - yPol;
+
+        // The complex multiplication below can be simplified because
+        // the real part of the phasor is 0.0. Boring implementation:
+        // const IT yPol90 = cuCmulf(yPol, makeuFloatComplex(0.0, 1.0));
+
+        const float x = -cuCimagf(yPol);
+        const float y = +cuCrealf(yPol);
+        const IT yPol90 = make_cuFloatComplex(x, y);
+
+        output[tid + 0] = cuCaddf(xPol, yPol90);
+        output[tid + 1] = cuCsubf(xPol, yPol90);
     }
 }

--- a/tests/modules/polarizer/polarizer.py
+++ b/tests/modules/polarizer/polarizer.py
@@ -57,12 +57,12 @@ if __name__ == "__main__":
     # Python Implementation
     #
 
-    py_input = bl_input.flatten().view(np.float32)
-    py_output = np.zeros((NBEAMS * NCHANS * NTIME * NPOLS), dtype=np.complex64).view(np.float32)
+    py_input = bl_input.flatten().view(np.complex64)
+    py_output = np.zeros((NBEAMS * NCHANS * NTIME * NPOLS), dtype=np.complex64)
 
     start = time.time()
-    py_output[0::2] = py_input[0::2] + py_input[1::2]
-    py_output[1::2] = py_input[0::2] - py_input[1::2]
+    py_output[0::2] = py_input[0::2] + 1j * py_input[1::2]
+    py_output[1::2] = py_input[0::2] - 1j * py_input[1::2]
     print(f"Detection with Python took {time.time()-start:.2f} s.")
 
     py_output = py_output.view(np.complex64)


### PR DESCRIPTION
This addresses #49 by adding a 90-degree phasor to the Y polarization. This also solves multiple problems with the previous implementation. It also extends `TypeInfo<1>` with `cudaType` and `cudaSize` variables replacing runtime commands `CudaType` and `CudaTypeSize`.