### PR TITLE
Add cuFFT callback support for channelizer.

### DIFF
--- a/benchmarks/helper.hh
+++ b/benchmarks/helper.hh
@@ -44,8 +44,9 @@ class CudaBenchmark {
     template<typename Block>
     static void Create(std::shared_ptr<Block>& module,
                        const typename Block::Config& config,
-                       const typename Block::Input& input) {
-        module = std::make_unique<Block>(config, input);
+                       const typename Block::Input& input, 
+                       const cudaStream_t& stream) {
+        module = std::make_unique<Block>(config, input, stream);
     }
 
  private:

--- a/benchmarks/history/log-v0-7-7.txt
+++ b/benchmarks/history/log-v0-7-7.txt
@@ -1,0 +1,256 @@
+Log of Meson test suite run on 2023-01-26T17:54:34.687112
+
+Inherited environment: SHELL=/usr/bin/zsh LSCOLORS=Gxfxcxdxbxegedabagacad COLORTERM=truecolor CSF_MDTVTexturesDirectory=/usr/share/opencascade/resources/Textures LESS=-R TERM_PROGRAM_VERSION=3.3a CONDA_EXE=/home/luigi/miniconda3/bin/conda _CE_M='' TMUX=/tmp/tmux-1000/default,10554,0 CSF_DrawPluginDefaults=/usr/share/opencascade/resources/DrawResources LC_ADDRESS=en_US.UTF-8 CSF_LANGUAGE=us DOTNET_ROOT=/usr/share/dotnet SSH_AUTH_SOCK=/tmp/ssh-XXXXypeP4B/agent.10109 CSF_MIGRATION_TYPES=/usr/share/opencascade/resources/StdResource/MigrationSheet.txt TMUX_PLUGIN_MANAGER_PATH=/home/luigi/.tmux/plugins/ LC_MONETARY=en_US.UTF-8 CSF_OCCTResourcePath=/usr/share/opencascade/resources CSF_STEPDefaults=/usr/share/opencascade/resources/XSTEPResource EDITOR=/usr/bin/nano PWD=/home/luigi/sandbox/blade/build LOGNAME=luigi QT_QPA_PLATFORMTHEME=qt5ct XDG_SESSION_TYPE=tty DRAWHOME=/usr/share/opencascade/resources/DrawResources _=/usr/bin/meson CSF_StandardLiteDefaults=/usr/share/opencascade/resources/StdResource RAWWAVE_PATH=/usr/share/stk/rawwaves MOTD_SHOWN=pam HOME=/home/luigi LC_PAPER=en_US.UTF-8 LANG=en_US.UTF-8 LS_COLORS='rs=0:di=01;34:ln=01;36:mh=00:pi=40;33:so=01;35:do=01;35:bd=40;33;01:cd=40;33;01:or=40;31;01:mi=00:su=37;41:sg=30;43:ca=00:tw=30;42:ow=34;42:st=37;44:ex=01;32:*.tar=01;31:*.tgz=01;31:*.arc=01;31:*.arj=01;31:*.taz=01;31:*.lha=01;31:*.lz4=01;31:*.lzh=01;31:*.lzma=01;31:*.tlz=01;31:*.txz=01;31:*.tzo=01;31:*.t7z=01;31:*.zip=01;31:*.z=01;31:*.dz=01;31:*.gz=01;31:*.lrz=01;31:*.lz=01;31:*.lzo=01;31:*.xz=01;31:*.zst=01;31:*.tzst=01;31:*.bz2=01;31:*.bz=01;31:*.tbz=01;31:*.tbz2=01;31:*.tz=01;31:*.deb=01;31:*.rpm=01;31:*.jar=01;31:*.war=01;31:*.ear=01;31:*.sar=01;31:*.rar=01;31:*.alz=01;31:*.ace=01;31:*.zoo=01;31:*.cpio=01;31:*.7z=01;31:*.rz=01;31:*.cab=01;31:*.wim=01;31:*.swm=01;31:*.dwm=01;31:*.esd=01;31:*.avif=01;35:*.jpg=01;35:*.jpeg=01;35:*.mjpg=01;35:*.mjpeg=01;35:*.gif=01;35:*.bmp=01;35:*.pbm=01;35:*.pgm=01;35:*.ppm=01;35:*.tga=01;35:*.xbm=01;35:*.xpm=01;35:*.tif=01;35:*.tiff=01;35:*.png=01;35:*.svg=01;35:*.svgz=01;35:*.mng=01;35:*.pcx=01;35:*.mov=01;35:*.mpg=01;35:*.mpeg=01;35:*.m2v=01;35:*.mkv=01;35:*.webm=01;35:*.webp=01;35:*.ogm=01;35:*.mp4=01;35:*.m4v=01;35:*.mp4v=01;35:*.vob=01;35:*.qt=01;35:*.nuv=01;35:*.wmv=01;35:*.asf=01;35:*.rm=01;35:*.rmvb=01;35:*.flc=01;35:*.avi=01;35:*.fli=01;35:*.flv=01;35:*.gl=01;35:*.dl=01;35:*.xcf=01;35:*.xwd=01;35:*.yuv=01;35:*.cgm=01;35:*.emf=01;35:*.ogv=01;35:*.ogx=01;35:*.aac=00;36:*.au=00;36:*.flac=00;36:*.m4a=00;36:*.mid=00;36:*.midi=00;36:*.mka=00;36:*.mp3=00;36:*.mpc=00;36:*.ogg=00;36:*.ra=00;36:*.wav=00;36:*.oga=00;36:*.opus=00;36:*.spx=00;36:*.xspf=00;36:*~=00;90:*#=00;90:*.bak=00;90:*.old=00;90:*.orig=00;90:*.part=00;90:*.rej=00;90:*.swp=00;90:*.tmp=00;90:*.dpkg-dist=00;90:*.dpkg-old=00;90:*.ucf-dist=00;90:*.ucf-new=00;90:*.ucf-old=00;90:*.rpmnew=00;90:*.rpmorig=00;90:*.rpmsave=00;90:' SSH_CONNECTION='10.10.5.229 51931 10.10.1.2 22' CSF_ShadersDirectory=/usr/share/opencascade/resources/Shaders DOTNET_BUNDLE_EXTRACT_BASE_DIR=/home/luigi/.cache/dotnet_bundle_extract CSF_EXCEPTION_PROMPT=1 CSF_XmlOcafResource=/usr/share/opencascade/resources/XmlOcafResource CSF_SHMessage=/usr/share/opencascade/resources/SHMessage OPCODE6DIR=/usr/lib/csound/plugins64-6.0 XDG_SESSION_CLASS=user TERM=xterm-256color ZSH=/home/luigi/.oh-my-zsh _CE_CONDA='' USER=luigi TMUX_PANE=%1 CUDA_PATH=/opt/cuda CONDA_SHLVL=0 CSF_StandardDefaults=/usr/share/opencascade/resources/StdResource CSF_IGESDefaults=/usr/share/opencascade/resources/XSTEPResource CSSTRNGS=/usr/share/locale CSF_XCAFDefaults=/usr/share/opencascade/resources/StdResource SHLVL=2 PAGER=less LC_MESSAGES=en_US.UTF-8 LC_MEASUREMENT=en_US.UTF-8 CSF_PluginDefaults=/usr/share/opencascade/resources/StdResource CSF_TObjMessage=/usr/share/opencascade/resources/TObj XDG_SESSION_ID=12 CASROOT=/usr CONDA_PYTHON_EXE=/home/luigi/miniconda3/bin/python XDG_RUNTIME_DIR=/run/user/1000 SSH_CLIENT='10.10.5.229 51931 22' MKLROOT=/opt/intel/oneapi/mkl/latest DEBUGINFOD_URLS='https://debuginfod.archlinux.org ' LC_TIME=en_US.UTF-8 CSF_XSMessage=/usr/share/opencascade/resources/XSMessage MMGT_CLEAR=1 XDG_DATA_DIRS=/home/luigi/.local/share/flatpak/exports/share:/var/lib/flatpak/exports/share:/usr/local/share:/usr/share PATH=/home/luigi/.poetry/bin:/home/luigi/.poetry/bin:/home/luigi/miniconda3/condabin:/home/luigi/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/bin:/opt/cuda/bin:/opt/cuda/nsight_compute:/opt/cuda/nsight_systems/bin:/home/luigi/.dotnet/tools:/usr/lib/emscripten:/home/luigi/.local/share/flatpak/exports/bin:/var/lib/flatpak/exports/bin:/usr/lib/jvm/default/bin:/usr/bin/site_perl:/usr/bin/vendor_perl:/usr/bin/core_perl:/opt/Xilinx/Vivado/2021.1/bin:/home/luigi/go/bin:/opt/cuda/bin:/opt/cuda/nsight_compute:/opt/cuda/nsight_systems/bin:/usr/lib/emscripten:/opt/Xilinx/Vivado/2021.1/bin:/home/luigi/go/bin CSF_TObjDefaults=/usr/share/opencascade/resources/StdResource DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/1000/bus MAIL=/var/spool/mail/luigi SSH_TTY=/dev/pts/0 DRAWDEFAULT=/usr/share/opencascade/resources/DrawResources/DrawDefault OLDPWD=/home/luigi/sandbox/blade TERM_PROGRAM=tmux 
+
+==================================== 1/8 =====================================
+test:         beamformer-ata-benchmark
+start time:   20:54:34
+duration:     80.20s
+result:       exit status 0
+command:      LD_LIBRARY_PATH=/home/luigi/sandbox/blade/build/subprojects/guppirawc99:/home/luigi/sandbox/blade/build/:/home/luigi/sandbox/blade/build/subprojects/bfr5c99:/home/luigi/sandbox/blade/build/subprojects/guppirawc99/subprojects/fitsheaderc99:/home/luigi/sandbox/blade/build/subprojects/radiointerferometryc99 /home/luigi/sandbox/blade/build/benchmarks/modules/beamformer/blade-beamformer-ata-benchmark
+----------------------------------- stdout -----------------------------------
+-----------------------------------------------------------------------------------------------------
+Benchmark                                                           Time             CPU   Iterations
+-----------------------------------------------------------------------------------------------------
+BM_BeamformerATA_Compute/1/20/iterations:16384/manual_time      0.625 ms        0.629 ms        16384
+BM_BeamformerATA_Compute/2/20/iterations:16384/manual_time      0.659 ms        0.664 ms        16384
+BM_BeamformerATA_Compute/8/20/iterations:16384/manual_time      0.850 ms        0.855 ms        16384
+BM_BeamformerATA_Compute/2/42/iterations:16384/manual_time       1.30 ms         1.30 ms        16384
+BM_BeamformerATA_Transfer/1/20/iterations:64/manual_time         40.2 ms         40.2 ms           64
+BM_BeamformerATA_Transfer/1/42/iterations:64/manual_time         84.9 ms         84.9 ms           64
+BM_BeamformerATA_Converged/1/20/iterations:64/manual_time        42.2 ms         42.2 ms           64
+BM_BeamformerATA_Converged/2/20/iterations:64/manual_time        42.3 ms         42.3 ms           64
+BM_BeamformerATA_Converged/8/20/iterations:64/manual_time        42.4 ms         42.4 ms           64
+BM_BeamformerATA_Converged/2/42/iterations:64/manual_time        87.3 ms         87.2 ms           64
+----------------------------------- stderr -----------------------------------
+2023-01-26T17:54:34-03:00
+Running /home/luigi/sandbox/blade/build/benchmarks/modules/beamformer/blade-beamformer-ata-benchmark
+Run on (8 X 4500 MHz CPU s)
+CPU Caches:
+  L1 Data 32 KiB (x4)
+  L1 Instruction 32 KiB (x4)
+  L2 Unified 256 KiB (x4)
+  L3 Unified 8192 KiB (x1)
+Load Average: 3.86, 1.60, 1.01
+***WARNING*** CPU scaling is enabled, the benchmark real time measurements may be noisy and will incur extra overhead.
+==============================================================================
+
+==================================== 2/8 =====================================
+test:         beamformer-meerkat-benchmark
+start time:   20:55:54
+duration:     47.95s
+result:       exit status 0
+command:      LD_LIBRARY_PATH=/home/luigi/sandbox/blade/build/subprojects/guppirawc99:/home/luigi/sandbox/blade/build/:/home/luigi/sandbox/blade/build/subprojects/bfr5c99:/home/luigi/sandbox/blade/build/subprojects/guppirawc99/subprojects/fitsheaderc99:/home/luigi/sandbox/blade/build/subprojects/radiointerferometryc99 /home/luigi/sandbox/blade/build/benchmarks/modules/beamformer/blade-beamformer-meerkat-benchmark
+----------------------------------- stdout -----------------------------------
+---------------------------------------------------------------------------------------------------------
+Benchmark                                                               Time             CPU   Iterations
+---------------------------------------------------------------------------------------------------------
+BM_BeamformerMEERKAT_Compute/1/20/iterations:16384/manual_time      0.622 ms        0.627 ms        16384
+BM_BeamformerMEERKAT_Compute/2/20/iterations:16384/manual_time      0.652 ms        0.656 ms        16384
+BM_BeamformerMEERKAT_Compute/8/20/iterations:16384/manual_time      0.927 ms        0.932 ms        16384
+BM_BeamformerMEERKAT_Transfer/1/20/iterations:64/manual_time         40.2 ms         40.2 ms           64
+BM_BeamformerMEERKAT_Converged/1/20/iterations:64/manual_time        41.7 ms         41.7 ms           64
+BM_BeamformerMEERKAT_Converged/2/20/iterations:64/manual_time        41.7 ms         41.7 ms           64
+BM_BeamformerMEERKAT_Converged/8/20/iterations:64/manual_time        42.0 ms         42.0 ms           64
+----------------------------------- stderr -----------------------------------
+2023-01-26T17:55:54-03:00
+Running /home/luigi/sandbox/blade/build/benchmarks/modules/beamformer/blade-beamformer-meerkat-benchmark
+Run on (8 X 4500 MHz CPU s)
+CPU Caches:
+  L1 Data 32 KiB (x4)
+  L1 Instruction 32 KiB (x4)
+  L2 Unified 256 KiB (x4)
+  L3 Unified 8192 KiB (x1)
+Load Average: 1.77, 1.48, 1.02
+***WARNING*** CPU scaling is enabled, the benchmark real time measurements may be noisy and will incur extra overhead.
+==============================================================================
+
+==================================== 3/8 =====================================
+test:         cast-benchmark
+start time:   20:56:42
+duration:     164.45s
+result:       exit status 0
+command:      LD_LIBRARY_PATH=/home/luigi/sandbox/blade/build/subprojects/guppirawc99:/home/luigi/sandbox/blade/build/:/home/luigi/sandbox/blade/build/subprojects/bfr5c99:/home/luigi/sandbox/blade/build/subprojects/guppirawc99/subprojects/fitsheaderc99:/home/luigi/sandbox/blade/build/subprojects/radiointerferometryc99 /home/luigi/sandbox/blade/build/benchmarks/modules/cast/blade-cast-benchmark
+----------------------------------- stdout -----------------------------------
+----------------------------------------------------------------------------------------------------
+Benchmark                                                          Time             CPU   Iterations
+----------------------------------------------------------------------------------------------------
+BM_Cast_Compute_CF32_CF32/2/iterations:16384/manual_time       0.129 ms        0.134 ms        16384
+BM_Cast_Compute_CF32_CF32/16/iterations:16384/manual_time      0.955 ms        0.959 ms        16384
+BM_Cast_Compute_CF32_CF32/64/iterations:16384/manual_time       3.78 ms         3.79 ms        16384
+BM_Cast_Transfer_CF32_CF32/2/iterations:64/manual_time          4.62 ms         4.80 ms           64
+BM_Cast_Transfer_CF32_CF32/16/iterations:64/manual_time         32.2 ms         32.2 ms           64
+BM_Cast_Transfer_CF32_CF32/64/iterations:64/manual_time          130 ms          130 ms           64
+BM_Cast_Converged_CF32_CF32/2/iterations:64/manual_time         5.66 ms         5.66 ms           64
+BM_Cast_Converged_CF32_CF32/16/iterations:64/manual_time        34.1 ms         34.1 ms           64
+BM_Cast_Converged_CF32_CF32/64/iterations:64/manual_time         133 ms          133 ms           64
+BM_Cast_Compute_CI8_CF32/2/iterations:16384/manual_time        0.090 ms        0.095 ms        16384
+BM_Cast_Compute_CI8_CF32/16/iterations:16384/manual_time       0.652 ms        0.657 ms        16384
+BM_Cast_Compute_CI8_CF32/64/iterations:16384/manual_time        2.58 ms         2.58 ms        16384
+BM_Cast_Transfer_CI8_CF32/2/iterations:64/manual_time           1.02 ms         1.54 ms           64
+BM_Cast_Transfer_CI8_CF32/16/iterations:64/manual_time          8.05 ms         8.05 ms           64
+BM_Cast_Transfer_CI8_CF32/64/iterations:64/manual_time          32.2 ms         32.2 ms           64
+BM_Cast_Converged_CI8_CF32/2/iterations:64/manual_time          2.67 ms         2.68 ms           64
+BM_Cast_Converged_CI8_CF32/16/iterations:64/manual_time         10.0 ms         10.0 ms           64
+BM_Cast_Converged_CI8_CF32/64/iterations:64/manual_time         35.8 ms         35.8 ms           64
+----------------------------------- stderr -----------------------------------
+2023-01-26T17:56:42-03:00
+Running /home/luigi/sandbox/blade/build/benchmarks/modules/cast/blade-cast-benchmark
+Run on (8 X 4500 MHz CPU s)
+CPU Caches:
+  L1 Data 32 KiB (x4)
+  L1 Instruction 32 KiB (x4)
+  L2 Unified 256 KiB (x4)
+  L3 Unified 8192 KiB (x1)
+Load Average: 1.36, 1.41, 1.01
+***WARNING*** CPU scaling is enabled, the benchmark real time measurements may be noisy and will incur extra overhead.
+==============================================================================
+
+==================================== 4/8 =====================================
+test:         detector-benchmark
+start time:   20:59:27
+duration:     161.07s
+result:       exit status 0
+command:      LD_LIBRARY_PATH=/home/luigi/sandbox/blade/build/subprojects/guppirawc99:/home/luigi/sandbox/blade/build/:/home/luigi/sandbox/blade/build/subprojects/bfr5c99:/home/luigi/sandbox/blade/build/subprojects/guppirawc99/subprojects/fitsheaderc99:/home/luigi/sandbox/blade/build/subprojects/radiointerferometryc99 /home/luigi/sandbox/blade/build/benchmarks/modules/detector/blade-detector-benchmark
+----------------------------------- stdout -----------------------------------
+---------------------------------------------------------------------------------------------------
+Benchmark                                                         Time             CPU   Iterations
+---------------------------------------------------------------------------------------------------
+BM_Detector_Compute/2/8/4/iterations:16384/manual_time        0.187 ms        0.192 ms        16384
+BM_Detector_Compute/16/8/4/iterations:16384/manual_time        1.39 ms         1.40 ms        16384
+BM_Detector_Compute/2/32/4/iterations:16384/manual_time       0.426 ms        0.431 ms        16384
+BM_Detector_Compute/16/32/4/iterations:16384/manual_time       3.39 ms         3.39 ms        16384
+BM_Detector_Compute/2/64/4/iterations:16384/manual_time       0.458 ms        0.462 ms        16384
+BM_Detector_Compute/16/64/4/iterations:16384/manual_time       3.61 ms         3.61 ms        16384
+BM_Detector_Transfer/2/8/4/iterations:64/manual_time           4.03 ms         4.03 ms           64
+BM_Detector_Transfer/16/8/4/iterations:64/manual_time          32.3 ms         32.3 ms           64
+BM_Detector_Converged/2/8/4/iterations:64/manual_time          5.80 ms         5.80 ms           64
+BM_Detector_Converged/16/8/4/iterations:64/manual_time         34.7 ms         34.7 ms           64
+----------------------------------- stderr -----------------------------------
+2023-01-26T17:59:27-03:00
+Running /home/luigi/sandbox/blade/build/benchmarks/modules/detector/blade-detector-benchmark
+Run on (8 X 4500 MHz CPU s)
+CPU Caches:
+  L1 Data 32 KiB (x4)
+  L1 Instruction 32 KiB (x4)
+  L2 Unified 256 KiB (x4)
+  L3 Unified 8192 KiB (x1)
+Load Average: 1.04, 1.25, 1.01
+***WARNING*** CPU scaling is enabled, the benchmark real time measurements may be noisy and will incur extra overhead.
+==============================================================================
+
+==================================== 5/8 =====================================
+test:         polarizer-benchmark
+start time:   21:02:08
+duration:     24.36s
+result:       exit status 0
+command:      LD_LIBRARY_PATH=/home/luigi/sandbox/blade/build/subprojects/guppirawc99:/home/luigi/sandbox/blade/build/:/home/luigi/sandbox/blade/build/subprojects/bfr5c99:/home/luigi/sandbox/blade/build/subprojects/guppirawc99/subprojects/fitsheaderc99:/home/luigi/sandbox/blade/build/subprojects/radiointerferometryc99 /home/luigi/sandbox/blade/build/benchmarks/modules/polarizer/blade-polarizer-benchmark
+----------------------------------- stdout -----------------------------------
+-------------------------------------------------------------------------------------------------
+Benchmark                                                       Time             CPU   Iterations
+-------------------------------------------------------------------------------------------------
+BM_Polarizer_Compute/2/1/iterations:16384/manual_time       0.135 ms        0.140 ms        16384
+BM_Polarizer_Compute/16/1/iterations:16384/manual_time       1.01 ms         1.01 ms        16384
+BM_Polarizer_Transfer/2/1/iterations:64/manual_time          4.01 ms         4.02 ms           64
+BM_Polarizer_Transfer/16/1/iterations:64/manual_time         32.2 ms         32.1 ms           64
+BM_Polarizer_Converged/2/1/iterations:64/manual_time         5.72 ms         5.72 ms           64
+BM_Polarizer_Converged/16/1/iterations:64/manual_time        34.2 ms         34.2 ms           64
+----------------------------------- stderr -----------------------------------
+2023-01-26T18:02:08-03:00
+Running /home/luigi/sandbox/blade/build/benchmarks/modules/polarizer/blade-polarizer-benchmark
+Run on (8 X 4500 MHz CPU s)
+CPU Caches:
+  L1 Data 32 KiB (x4)
+  L1 Instruction 32 KiB (x4)
+  L2 Unified 256 KiB (x4)
+  L3 Unified 8192 KiB (x1)
+Load Average: 1.00, 1.14, 1.00
+***WARNING*** CPU scaling is enabled, the benchmark real time measurements may be noisy and will incur extra overhead.
+==============================================================================
+
+==================================== 6/8 =====================================
+test:         channelizer-benchmark
+start time:   21:02:32
+duration:     155.33s
+result:       exit status 0
+command:      LD_LIBRARY_PATH=/home/luigi/sandbox/blade/build/subprojects/guppirawc99:/home/luigi/sandbox/blade/build/:/home/luigi/sandbox/blade/build/subprojects/bfr5c99:/home/luigi/sandbox/blade/build/subprojects/guppirawc99/subprojects/fitsheaderc99:/home/luigi/sandbox/blade/build/subprojects/radiointerferometryc99 /home/luigi/sandbox/blade/build/benchmarks/modules/channelizer/blade-channelizer-benchmark
+----------------------------------- stdout -----------------------------------
+------------------------------------------------------------------------------------------------------
+Benchmark                                                            Time             CPU   Iterations
+------------------------------------------------------------------------------------------------------
+BM_Channelizer_Compute/16/4/iterations:16384/manual_time          1.06 ms         1.07 ms        16384
+BM_Channelizer_Compute/16/64/iterations:16384/manual_time         4.52 ms         4.52 ms        16384
+BM_Channelizer_Compute/16/8192/iterations:16384/manual_time       3.10 ms         3.10 ms        16384
+BM_Channelizer_Transfer/16/4/iterations:64/manual_time            32.2 ms         32.2 ms           64
+BM_Channelizer_Transfer/16/8192/iterations:64/manual_time         32.2 ms         32.2 ms           64
+BM_Channelizer_Converged/16/4/iterations:64/manual_time           34.5 ms         34.5 ms           64
+BM_Channelizer_Converged/16/64/iterations:64/manual_time          40.5 ms         40.5 ms           64
+BM_Channelizer_Converged/16/8192/iterations:64/manual_time        36.3 ms         36.3 ms           64
+----------------------------------- stderr -----------------------------------
+2023-01-26T18:02:32-03:00
+Running /home/luigi/sandbox/blade/build/benchmarks/modules/channelizer/blade-channelizer-benchmark
+Run on (8 X 4500 MHz CPU s)
+CPU Caches:
+  L1 Data 32 KiB (x4)
+  L1 Instruction 32 KiB (x4)
+  L2 Unified 256 KiB (x4)
+  L3 Unified 8192 KiB (x1)
+Load Average: 1.00, 1.13, 1.00
+***WARNING*** CPU scaling is enabled, the benchmark real time measurements may be noisy and will incur extra overhead.
+==============================================================================
+
+==================================== 7/8 =====================================
+test:         blade-ata-mode-b-benchmark
+start time:   21:05:08
+duration:     184.43s
+result:       exit status 0
+command:      LD_LIBRARY_PATH=/home/luigi/sandbox/blade/build/subprojects/guppirawc99:/home/luigi/sandbox/blade/build/:/home/luigi/sandbox/blade/build/subprojects/bfr5c99:/home/luigi/sandbox/blade/build/subprojects/guppirawc99/subprojects/fitsheaderc99:/home/luigi/sandbox/blade/build/subprojects/radiointerferometryc99 /home/luigi/sandbox/blade/build/benchmarks/pipelines/ata/mode-b/blade-ata-mode-b-benchmark
+----------------------------------- stdout -----------------------------------
+------------------------------------------------------------------------------------
+Benchmark                                          Time             CPU   Iterations
+------------------------------------------------------------------------------------
+BM_PipelineModeB/iterations:8/manual_time       11.2 ms        22983 ms            8
+----------------------------------- stderr -----------------------------------
+2023-01-26T18:05:08-03:00
+Running /home/luigi/sandbox/blade/build/benchmarks/pipelines/ata/mode-b/blade-ata-mode-b-benchmark
+Run on (8 X 4500 MHz CPU s)
+CPU Caches:
+  L1 Data 32 KiB (x4)
+  L1 Instruction 32 KiB (x4)
+  L2 Unified 256 KiB (x4)
+  L3 Unified 8192 KiB (x1)
+Load Average: 1.02, 1.08, 1.00
+***WARNING*** CPU scaling is enabled, the benchmark real time measurements may be noisy and will incur extra overhead.
+==============================================================================
+
+==================================== 8/8 =====================================
+test:         blade-ata-mode-bh-benchmark
+start time:   21:08:12
+duration:     27.07s
+result:       exit status 0
+command:      LD_LIBRARY_PATH=/home/luigi/sandbox/blade/build/subprojects/guppirawc99:/home/luigi/sandbox/blade/build/:/home/luigi/sandbox/blade/build/subprojects/bfr5c99:/home/luigi/sandbox/blade/build/subprojects/guppirawc99/subprojects/fitsheaderc99:/home/luigi/sandbox/blade/build/subprojects/radiointerferometryc99 /home/luigi/sandbox/blade/build/benchmarks/pipelines/ata/mode-bh/blade-ata-mode-bh-benchmark
+----------------------------------- stdout -----------------------------------
+-------------------------------------------------------------------------------------
+Benchmark                                           Time             CPU   Iterations
+-------------------------------------------------------------------------------------
+BM_PipelineModeBH/iterations:8/manual_time       1.63 ms         3328 ms            8
+----------------------------------- stderr -----------------------------------
+2023-01-26T18:08:12-03:00
+Running /home/luigi/sandbox/blade/build/benchmarks/pipelines/ata/mode-bh/blade-ata-mode-bh-benchmark
+Run on (8 X 4500 MHz CPU s)
+CPU Caches:
+  L1 Data 32 KiB (x4)
+  L1 Instruction 32 KiB (x4)
+  L2 Unified 256 KiB (x4)
+  L3 Unified 8192 KiB (x1)
+Load Average: 1.40, 1.19, 1.05
+***WARNING*** CPU scaling is enabled, the benchmark real time measurements may be noisy and will incur extra overhead.
+==============================================================================
+
+
+Ok:                 8   
+Expected Fail:      0   
+Fail:               0   
+Unexpected Pass:    0   
+Skipped:            0   
+Timeout:            0   

--- a/benchmarks/history/log-v0-8-0.txt
+++ b/benchmarks/history/log-v0-8-0.txt
@@ -1,0 +1,251 @@
+Log of Meson test suite run on 2023-02-02T18:15:08.298736
+
+Inherited environment: SHELL=/usr/bin/zsh LSCOLORS=Gxfxcxdxbxegedabagacad COLORTERM=truecolor CSF_MDTVTexturesDirectory=/usr/share/opencascade/resources/Textures LESS=-R TERM_PROGRAM_VERSION=3.3a CONDA_EXE=/home/luigi/miniconda3/bin/conda _CE_M='' TMUX=/tmp/tmux-1000/default,1652,0 CSF_DrawPluginDefaults=/usr/share/opencascade/resources/DrawResources LC_ADDRESS=en_US.UTF-8 CSF_LANGUAGE=us DOTNET_ROOT=/usr/share/dotnet SSH_AUTH_SOCK=/tmp/ssh-XXXXHyd1fR/agent.1638 CSF_MIGRATION_TYPES=/usr/share/opencascade/resources/StdResource/MigrationSheet.txt TMUX_PLUGIN_MANAGER_PATH=/home/luigi/.tmux/plugins/ LC_MONETARY=en_US.UTF-8 CSF_OCCTResourcePath=/usr/share/opencascade/resources CSF_STEPDefaults=/usr/share/opencascade/resources/XSTEPResource EDITOR=/usr/bin/nano PWD=/home/luigi/sandbox/blade/build LOGNAME=luigi QT_QPA_PLATFORMTHEME=qt5ct XDG_SESSION_TYPE=tty DRAWHOME=/usr/share/opencascade/resources/DrawResources _=/usr/bin/meson CSF_StandardLiteDefaults=/usr/share/opencascade/resources/StdResource RAWWAVE_PATH=/usr/share/stk/rawwaves MOTD_SHOWN=pam HOME=/home/luigi LC_PAPER=en_US.UTF-8 LANG=en_US.UTF-8 LS_COLORS='rs=0:di=01;34:ln=01;36:mh=00:pi=40;33:so=01;35:do=01;35:bd=40;33;01:cd=40;33;01:or=40;31;01:mi=00:su=37;41:sg=30;43:ca=00:tw=30;42:ow=34;42:st=37;44:ex=01;32:*.tar=01;31:*.tgz=01;31:*.arc=01;31:*.arj=01;31:*.taz=01;31:*.lha=01;31:*.lz4=01;31:*.lzh=01;31:*.lzma=01;31:*.tlz=01;31:*.txz=01;31:*.tzo=01;31:*.t7z=01;31:*.zip=01;31:*.z=01;31:*.dz=01;31:*.gz=01;31:*.lrz=01;31:*.lz=01;31:*.lzo=01;31:*.xz=01;31:*.zst=01;31:*.tzst=01;31:*.bz2=01;31:*.bz=01;31:*.tbz=01;31:*.tbz2=01;31:*.tz=01;31:*.deb=01;31:*.rpm=01;31:*.jar=01;31:*.war=01;31:*.ear=01;31:*.sar=01;31:*.rar=01;31:*.alz=01;31:*.ace=01;31:*.zoo=01;31:*.cpio=01;31:*.7z=01;31:*.rz=01;31:*.cab=01;31:*.wim=01;31:*.swm=01;31:*.dwm=01;31:*.esd=01;31:*.avif=01;35:*.jpg=01;35:*.jpeg=01;35:*.mjpg=01;35:*.mjpeg=01;35:*.gif=01;35:*.bmp=01;35:*.pbm=01;35:*.pgm=01;35:*.ppm=01;35:*.tga=01;35:*.xbm=01;35:*.xpm=01;35:*.tif=01;35:*.tiff=01;35:*.png=01;35:*.svg=01;35:*.svgz=01;35:*.mng=01;35:*.pcx=01;35:*.mov=01;35:*.mpg=01;35:*.mpeg=01;35:*.m2v=01;35:*.mkv=01;35:*.webm=01;35:*.webp=01;35:*.ogm=01;35:*.mp4=01;35:*.m4v=01;35:*.mp4v=01;35:*.vob=01;35:*.qt=01;35:*.nuv=01;35:*.wmv=01;35:*.asf=01;35:*.rm=01;35:*.rmvb=01;35:*.flc=01;35:*.avi=01;35:*.fli=01;35:*.flv=01;35:*.gl=01;35:*.dl=01;35:*.xcf=01;35:*.xwd=01;35:*.yuv=01;35:*.cgm=01;35:*.emf=01;35:*.ogv=01;35:*.ogx=01;35:*.aac=00;36:*.au=00;36:*.flac=00;36:*.m4a=00;36:*.mid=00;36:*.midi=00;36:*.mka=00;36:*.mp3=00;36:*.mpc=00;36:*.ogg=00;36:*.ra=00;36:*.wav=00;36:*.oga=00;36:*.opus=00;36:*.spx=00;36:*.xspf=00;36:*~=00;90:*#=00;90:*.bak=00;90:*.old=00;90:*.orig=00;90:*.part=00;90:*.rej=00;90:*.swp=00;90:*.tmp=00;90:*.dpkg-dist=00;90:*.dpkg-old=00;90:*.ucf-dist=00;90:*.ucf-new=00;90:*.ucf-old=00;90:*.rpmnew=00;90:*.rpmorig=00;90:*.rpmsave=00;90:' SSH_CONNECTION='10.10.5.229 57190 10.10.1.2 22' CSF_ShadersDirectory=/usr/share/opencascade/resources/Shaders DOTNET_BUNDLE_EXTRACT_BASE_DIR=/home/luigi/.cache/dotnet_bundle_extract CSF_EXCEPTION_PROMPT=1 CSF_XmlOcafResource=/usr/share/opencascade/resources/XmlOcafResource CSF_SHMessage=/usr/share/opencascade/resources/SHMessage OPCODE6DIR=/usr/lib/csound/plugins64-6.0 XDG_SESSION_CLASS=user TERM=xterm-256color ZSH=/home/luigi/.oh-my-zsh _CE_CONDA='' USER=luigi TMUX_PANE=%1 CUDA_PATH=/opt/cuda CONDA_SHLVL=0 CSF_StandardDefaults=/usr/share/opencascade/resources/StdResource CSF_IGESDefaults=/usr/share/opencascade/resources/XSTEPResource CSSTRNGS=/usr/share/locale CSF_XCAFDefaults=/usr/share/opencascade/resources/StdResource SHLVL=2 PAGER=less LC_MESSAGES=en_US.UTF-8 LC_MEASUREMENT=en_US.UTF-8 CSF_PluginDefaults=/usr/share/opencascade/resources/StdResource CSF_TObjMessage=/usr/share/opencascade/resources/TObj XDG_SESSION_ID=4 CASROOT=/usr CONDA_PYTHON_EXE=/home/luigi/miniconda3/bin/python XDG_RUNTIME_DIR=/run/user/1000 SSH_CLIENT='10.10.5.229 57190 22' MKLROOT=/opt/intel/oneapi/mkl/latest DEBUGINFOD_URLS='https://debuginfod.archlinux.org ' LC_TIME=en_US.UTF-8 CSF_XSMessage=/usr/share/opencascade/resources/XSMessage MMGT_CLEAR=1 XDG_DATA_DIRS=/home/luigi/.local/share/flatpak/exports/share:/var/lib/flatpak/exports/share:/usr/local/share:/usr/share PATH=/home/luigi/.poetry/bin:/home/luigi/miniconda3/condabin:/home/luigi/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/bin:/opt/cuda/bin:/opt/cuda/nsight_compute:/opt/cuda/nsight_systems/bin:/home/luigi/.dotnet/tools:/usr/lib/emscripten:/home/luigi/.local/share/flatpak/exports/bin:/var/lib/flatpak/exports/bin:/usr/lib/jvm/default/bin:/usr/bin/site_perl:/usr/bin/vendor_perl:/usr/bin/core_perl:/opt/cuda/bin:/opt/cuda/nsight_compute:/opt/cuda/nsight_systems/bin:/usr/lib/emscripten:/opt/Xilinx/Vivado/2021.1/bin:/home/luigi/go/bin CSF_TObjDefaults=/usr/share/opencascade/resources/StdResource DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/1000/bus MAIL=/var/spool/mail/luigi SSH_TTY=/dev/pts/0 DRAWDEFAULT=/usr/share/opencascade/resources/DrawResources/DrawDefault OLDPWD=/home/luigi/sandbox/blade TERM_PROGRAM=tmux 
+
+==================================== 1/8 =====================================
+test:         beamformer-ata-benchmark
+start time:   21:15:08
+duration:     79.85s
+result:       exit status 0
+command:      LD_LIBRARY_PATH=/home/luigi/sandbox/blade/build/subprojects/bfr5c99:/home/luigi/sandbox/blade/build/:/home/luigi/sandbox/blade/build/subprojects/radiointerferometryc99:/home/luigi/sandbox/blade/build/subprojects/guppirawc99/subprojects/fitsheaderc99:/home/luigi/sandbox/blade/build/subprojects/guppirawc99 /home/luigi/sandbox/blade/build/benchmarks/modules/beamformer/blade-beamformer-ata-benchmark
+----------------------------------- stdout -----------------------------------
+-----------------------------------------------------------------------------------------------------
+Benchmark                                                           Time             CPU   Iterations
+-----------------------------------------------------------------------------------------------------
+BM_BeamformerATA_Compute/1/20/iterations:16384/manual_time      0.624 ms        0.628 ms        16384
+BM_BeamformerATA_Compute/2/20/iterations:16384/manual_time      0.659 ms        0.663 ms        16384
+BM_BeamformerATA_Compute/8/20/iterations:16384/manual_time      0.850 ms        0.853 ms        16384
+BM_BeamformerATA_Compute/2/42/iterations:16384/manual_time       1.30 ms         1.30 ms        16384
+BM_BeamformerATA_Transfer/1/20/iterations:64/manual_time         39.5 ms         39.5 ms           64
+BM_BeamformerATA_Transfer/1/42/iterations:64/manual_time         83.5 ms         83.5 ms           64
+BM_BeamformerATA_Converged/1/20/iterations:64/manual_time        41.6 ms         41.5 ms           64
+BM_BeamformerATA_Converged/2/20/iterations:64/manual_time        41.6 ms         41.6 ms           64
+BM_BeamformerATA_Converged/8/20/iterations:64/manual_time        41.8 ms         41.8 ms           64
+BM_BeamformerATA_Converged/2/42/iterations:64/manual_time        85.9 ms         85.8 ms           64
+----------------------------------- stderr -----------------------------------
+2023-02-02T18:15:08-03:00
+Running /home/luigi/sandbox/blade/build/benchmarks/modules/beamformer/blade-beamformer-ata-benchmark
+Run on (8 X 4500 MHz CPU s)
+CPU Caches:
+  L1 Data 32 KiB (x4)
+  L1 Instruction 32 KiB (x4)
+  L2 Unified 256 KiB (x4)
+  L3 Unified 8192 KiB (x1)
+Load Average: 0.58, 0.19, 0.23
+***WARNING*** CPU scaling is enabled, the benchmark real time measurements may be noisy and will incur extra overhead.
+==============================================================================
+
+==================================== 2/8 =====================================
+test:         beamformer-meerkat-benchmark
+start time:   21:16:28
+duration:     48.18s
+result:       exit status 0
+command:      LD_LIBRARY_PATH=/home/luigi/sandbox/blade/build/subprojects/bfr5c99:/home/luigi/sandbox/blade/build/:/home/luigi/sandbox/blade/build/subprojects/radiointerferometryc99:/home/luigi/sandbox/blade/build/subprojects/guppirawc99/subprojects/fitsheaderc99:/home/luigi/sandbox/blade/build/subprojects/guppirawc99 /home/luigi/sandbox/blade/build/benchmarks/modules/beamformer/blade-beamformer-meerkat-benchmark
+----------------------------------- stdout -----------------------------------
+---------------------------------------------------------------------------------------------------------
+Benchmark                                                               Time             CPU   Iterations
+---------------------------------------------------------------------------------------------------------
+BM_BeamformerMEERKAT_Compute/1/20/iterations:16384/manual_time      0.622 ms        0.626 ms        16384
+BM_BeamformerMEERKAT_Compute/2/20/iterations:16384/manual_time      0.652 ms        0.656 ms        16384
+BM_BeamformerMEERKAT_Compute/8/20/iterations:16384/manual_time      0.950 ms        0.954 ms        16384
+BM_BeamformerMEERKAT_Transfer/1/20/iterations:64/manual_time         39.6 ms         39.6 ms           64
+BM_BeamformerMEERKAT_Converged/1/20/iterations:64/manual_time        41.2 ms         41.1 ms           64
+BM_BeamformerMEERKAT_Converged/2/20/iterations:64/manual_time        41.2 ms         41.2 ms           64
+BM_BeamformerMEERKAT_Converged/8/20/iterations:64/manual_time        41.5 ms         41.5 ms           64
+----------------------------------- stderr -----------------------------------
+2023-02-02T18:16:28-03:00
+Running /home/luigi/sandbox/blade/build/benchmarks/modules/beamformer/blade-beamformer-meerkat-benchmark
+Run on (8 X 4500 MHz CPU s)
+CPU Caches:
+  L1 Data 32 KiB (x4)
+  L1 Instruction 32 KiB (x4)
+  L2 Unified 256 KiB (x4)
+  L3 Unified 8192 KiB (x1)
+Load Average: 0.89, 0.39, 0.29
+***WARNING*** CPU scaling is enabled, the benchmark real time measurements may be noisy and will incur extra overhead.
+==============================================================================
+
+==================================== 3/8 =====================================
+test:         cast-benchmark
+start time:   21:17:16
+duration:     163.98s
+result:       exit status 0
+command:      LD_LIBRARY_PATH=/home/luigi/sandbox/blade/build/subprojects/bfr5c99:/home/luigi/sandbox/blade/build/:/home/luigi/sandbox/blade/build/subprojects/radiointerferometryc99:/home/luigi/sandbox/blade/build/subprojects/guppirawc99/subprojects/fitsheaderc99:/home/luigi/sandbox/blade/build/subprojects/guppirawc99 /home/luigi/sandbox/blade/build/benchmarks/modules/cast/blade-cast-benchmark
+----------------------------------- stdout -----------------------------------
+----------------------------------------------------------------------------------------------------
+Benchmark                                                          Time             CPU   Iterations
+----------------------------------------------------------------------------------------------------
+BM_Cast_Compute_CF32_CF32/2/iterations:16384/manual_time       0.129 ms        0.134 ms        16384
+BM_Cast_Compute_CF32_CF32/16/iterations:16384/manual_time      0.955 ms        0.960 ms        16384
+BM_Cast_Compute_CF32_CF32/64/iterations:16384/manual_time       3.78 ms         3.79 ms        16384
+BM_Cast_Transfer_CF32_CF32/2/iterations:64/manual_time          4.55 ms         4.73 ms           64
+BM_Cast_Transfer_CF32_CF32/16/iterations:64/manual_time         31.7 ms         31.7 ms           64
+BM_Cast_Transfer_CF32_CF32/64/iterations:64/manual_time          127 ms          127 ms           64
+BM_Cast_Converged_CF32_CF32/2/iterations:64/manual_time         5.60 ms         5.60 ms           64
+BM_Cast_Converged_CF32_CF32/16/iterations:64/manual_time        33.6 ms         33.6 ms           64
+BM_Cast_Converged_CF32_CF32/64/iterations:64/manual_time         131 ms          131 ms           64
+BM_Cast_Compute_CI8_CF32/2/iterations:16384/manual_time        0.090 ms        0.095 ms        16384
+BM_Cast_Compute_CI8_CF32/16/iterations:16384/manual_time       0.653 ms        0.657 ms        16384
+BM_Cast_Compute_CI8_CF32/64/iterations:16384/manual_time        2.58 ms         2.58 ms        16384
+BM_Cast_Transfer_CI8_CF32/2/iterations:64/manual_time           1.01 ms         1.52 ms           64
+BM_Cast_Transfer_CI8_CF32/16/iterations:64/manual_time          7.92 ms         7.92 ms           64
+BM_Cast_Transfer_CI8_CF32/64/iterations:64/manual_time          31.8 ms         31.8 ms           64
+BM_Cast_Converged_CI8_CF32/2/iterations:64/manual_time          2.65 ms         2.65 ms           64
+BM_Cast_Converged_CI8_CF32/16/iterations:64/manual_time         9.92 ms         9.92 ms           64
+BM_Cast_Converged_CI8_CF32/64/iterations:64/manual_time         35.3 ms         35.3 ms           64
+----------------------------------- stderr -----------------------------------
+2023-02-02T18:17:16-03:00
+Running /home/luigi/sandbox/blade/build/benchmarks/modules/cast/blade-cast-benchmark
+Run on (8 X 4500 MHz CPU s)
+CPU Caches:
+  L1 Data 32 KiB (x4)
+  L1 Instruction 32 KiB (x4)
+  L2 Unified 256 KiB (x4)
+  L3 Unified 8192 KiB (x1)
+Load Average: 0.95, 0.48, 0.33
+***WARNING*** CPU scaling is enabled, the benchmark real time measurements may be noisy and will incur extra overhead.
+==============================================================================
+
+==================================== 4/8 =====================================
+test:         detector-benchmark
+start time:   21:20:00
+duration:     160.58s
+result:       exit status 0
+command:      LD_LIBRARY_PATH=/home/luigi/sandbox/blade/build/subprojects/bfr5c99:/home/luigi/sandbox/blade/build/:/home/luigi/sandbox/blade/build/subprojects/radiointerferometryc99:/home/luigi/sandbox/blade/build/subprojects/guppirawc99/subprojects/fitsheaderc99:/home/luigi/sandbox/blade/build/subprojects/guppirawc99 /home/luigi/sandbox/blade/build/benchmarks/modules/detector/blade-detector-benchmark
+----------------------------------- stdout -----------------------------------
+---------------------------------------------------------------------------------------------------
+Benchmark                                                         Time             CPU   Iterations
+---------------------------------------------------------------------------------------------------
+BM_Detector_Compute/2/8/4/iterations:16384/manual_time        0.187 ms        0.191 ms        16384
+BM_Detector_Compute/16/8/4/iterations:16384/manual_time        1.39 ms         1.39 ms        16384
+BM_Detector_Compute/2/32/4/iterations:16384/manual_time       0.424 ms        0.429 ms        16384
+BM_Detector_Compute/16/32/4/iterations:16384/manual_time       3.38 ms         3.38 ms        16384
+BM_Detector_Compute/2/64/4/iterations:16384/manual_time       0.456 ms        0.461 ms        16384
+BM_Detector_Compute/16/64/4/iterations:16384/manual_time       3.60 ms         3.61 ms        16384
+BM_Detector_Transfer/2/8/4/iterations:64/manual_time           3.95 ms         3.96 ms           64
+BM_Detector_Transfer/16/8/4/iterations:64/manual_time          31.8 ms         31.8 ms           64
+BM_Detector_Converged/2/8/4/iterations:64/manual_time          5.74 ms         5.74 ms           64
+BM_Detector_Converged/16/8/4/iterations:64/manual_time         34.2 ms         34.2 ms           64
+----------------------------------- stderr -----------------------------------
+2023-02-02T18:20:00-03:00
+Running /home/luigi/sandbox/blade/build/benchmarks/modules/detector/blade-detector-benchmark
+Run on (8 X 4500 MHz CPU s)
+CPU Caches:
+  L1 Data 32 KiB (x4)
+  L1 Instruction 32 KiB (x4)
+  L2 Unified 256 KiB (x4)
+  L3 Unified 8192 KiB (x1)
+Load Average: 1.05, 0.73, 0.46
+***WARNING*** CPU scaling is enabled, the benchmark real time measurements may be noisy and will incur extra overhead.
+==============================================================================
+
+==================================== 5/8 =====================================
+test:         polarizer-benchmark
+start time:   21:22:40
+duration:     24.20s
+result:       exit status 0
+command:      LD_LIBRARY_PATH=/home/luigi/sandbox/blade/build/subprojects/bfr5c99:/home/luigi/sandbox/blade/build/:/home/luigi/sandbox/blade/build/subprojects/radiointerferometryc99:/home/luigi/sandbox/blade/build/subprojects/guppirawc99/subprojects/fitsheaderc99:/home/luigi/sandbox/blade/build/subprojects/guppirawc99 /home/luigi/sandbox/blade/build/benchmarks/modules/polarizer/blade-polarizer-benchmark
+----------------------------------- stdout -----------------------------------
+-------------------------------------------------------------------------------------------------
+Benchmark                                                       Time             CPU   Iterations
+-------------------------------------------------------------------------------------------------
+BM_Polarizer_Compute/2/1/iterations:16384/manual_time       0.134 ms        0.138 ms        16384
+BM_Polarizer_Compute/16/1/iterations:16384/manual_time       1.00 ms         1.01 ms        16384
+BM_Polarizer_Transfer/2/1/iterations:64/manual_time          3.95 ms         3.95 ms           64
+BM_Polarizer_Transfer/16/1/iterations:64/manual_time         31.6 ms         31.6 ms           64
+BM_Polarizer_Converged/2/1/iterations:64/manual_time         5.65 ms         5.65 ms           64
+BM_Polarizer_Converged/16/1/iterations:64/manual_time        33.8 ms         33.8 ms           64
+----------------------------------- stderr -----------------------------------
+2023-02-02T18:22:40-03:00
+Running /home/luigi/sandbox/blade/build/benchmarks/modules/polarizer/blade-polarizer-benchmark
+Run on (8 X 4500 MHz CPU s)
+CPU Caches:
+  L1 Data 32 KiB (x4)
+  L1 Instruction 32 KiB (x4)
+  L2 Unified 256 KiB (x4)
+  L3 Unified 8192 KiB (x1)
+Load Average: 1.00, 0.85, 0.55
+***WARNING*** CPU scaling is enabled, the benchmark real time measurements may be noisy and will incur extra overhead.
+==============================================================================
+
+==================================== 6/8 =====================================
+test:         channelizer-benchmark
+start time:   21:23:05
+duration:     71.44s
+result:       exit status 0
+command:      LD_LIBRARY_PATH=/home/luigi/sandbox/blade/build/subprojects/bfr5c99:/home/luigi/sandbox/blade/build/:/home/luigi/sandbox/blade/build/subprojects/radiointerferometryc99:/home/luigi/sandbox/blade/build/subprojects/guppirawc99/subprojects/fitsheaderc99:/home/luigi/sandbox/blade/build/subprojects/guppirawc99 /home/luigi/sandbox/blade/build/benchmarks/modules/channelizer/blade-channelizer-benchmark
+----------------------------------- stdout -----------------------------------
+------------------------------------------------------------------------------------------------------
+Benchmark                                                            Time             CPU   Iterations
+------------------------------------------------------------------------------------------------------
+BM_Channelizer_Compute/16/8192/iterations:16384/manual_time       4.05 ms         4.05 ms        16384
+BM_Channelizer_Transfer/16/8192/iterations:64/manual_time         32.2 ms         32.2 ms           64
+BM_Channelizer_Converged/16/8192/iterations:64/manual_time        36.3 ms         36.2 ms           64
+----------------------------------- stderr -----------------------------------
+2023-02-02T18:23:05-03:00
+Running /home/luigi/sandbox/blade/build/benchmarks/modules/channelizer/blade-channelizer-benchmark
+Run on (8 X 4500 MHz CPU s)
+CPU Caches:
+  L1 Data 32 KiB (x4)
+  L1 Instruction 32 KiB (x4)
+  L2 Unified 256 KiB (x4)
+  L3 Unified 8192 KiB (x1)
+Load Average: 1.00, 0.86, 0.57
+***WARNING*** CPU scaling is enabled, the benchmark real time measurements may be noisy and will incur extra overhead.
+==============================================================================
+
+==================================== 7/8 =====================================
+test:         blade-ata-mode-b-benchmark
+start time:   21:24:16
+duration:     201.74s
+result:       exit status 0
+command:      LD_LIBRARY_PATH=/home/luigi/sandbox/blade/build/subprojects/bfr5c99:/home/luigi/sandbox/blade/build/:/home/luigi/sandbox/blade/build/subprojects/radiointerferometryc99:/home/luigi/sandbox/blade/build/subprojects/guppirawc99/subprojects/fitsheaderc99:/home/luigi/sandbox/blade/build/subprojects/guppirawc99 /home/luigi/sandbox/blade/build/benchmarks/pipelines/ata/mode-b/blade-ata-mode-b-benchmark
+----------------------------------- stdout -----------------------------------
+------------------------------------------------------------------------------------
+Benchmark                                          Time             CPU   Iterations
+------------------------------------------------------------------------------------
+BM_PipelineModeB/iterations:8/manual_time       12.3 ms        25096 ms            8
+----------------------------------- stderr -----------------------------------
+2023-02-02T18:24:16-03:00
+Running /home/luigi/sandbox/blade/build/benchmarks/pipelines/ata/mode-b/blade-ata-mode-b-benchmark
+Run on (8 X 4500 MHz CPU s)
+CPU Caches:
+  L1 Data 32 KiB (x4)
+  L1 Instruction 32 KiB (x4)
+  L2 Unified 256 KiB (x4)
+  L3 Unified 8192 KiB (x1)
+Load Average: 1.00, 0.90, 0.60
+***WARNING*** CPU scaling is enabled, the benchmark real time measurements may be noisy and will incur extra overhead.
+==============================================================================
+
+==================================== 8/8 =====================================
+test:         blade-ata-mode-bh-benchmark
+start time:   21:27:38
+duration:     25.93s
+result:       exit status 0
+command:      LD_LIBRARY_PATH=/home/luigi/sandbox/blade/build/subprojects/bfr5c99:/home/luigi/sandbox/blade/build/:/home/luigi/sandbox/blade/build/subprojects/radiointerferometryc99:/home/luigi/sandbox/blade/build/subprojects/guppirawc99/subprojects/fitsheaderc99:/home/luigi/sandbox/blade/build/subprojects/guppirawc99 /home/luigi/sandbox/blade/build/benchmarks/pipelines/ata/mode-bh/blade-ata-mode-bh-benchmark
+----------------------------------- stdout -----------------------------------
+-------------------------------------------------------------------------------------
+Benchmark                                           Time             CPU   Iterations
+-------------------------------------------------------------------------------------
+BM_PipelineModeBH/iterations:8/manual_time       1.56 ms         3127 ms            8
+----------------------------------- stderr -----------------------------------
+2023-02-02T18:27:38-03:00
+Running /home/luigi/sandbox/blade/build/benchmarks/pipelines/ata/mode-bh/blade-ata-mode-bh-benchmark
+Run on (8 X 4500 MHz CPU s)
+CPU Caches:
+  L1 Data 32 KiB (x4)
+  L1 Instruction 32 KiB (x4)
+  L2 Unified 256 KiB (x4)
+  L3 Unified 8192 KiB (x1)
+Load Average: 1.27, 1.08, 0.74
+***WARNING*** CPU scaling is enabled, the benchmark real time measurements may be noisy and will incur extra overhead.
+==============================================================================
+
+
+Ok:                 8   
+Expected Fail:      0   
+Fail:               0   
+Unexpected Pass:    0   
+Skipped:            0   
+Timeout:            0   

--- a/benchmarks/modules/beamformer/generic.hh
+++ b/benchmarks/modules/beamformer/generic.hh
@@ -135,7 +135,7 @@ protected:
         Create(module, config, {
             .buf = deviceInputBuf, 
             .phasors = deviceInputPhasors,
-        });
+        }, this->getStream());
         BL_ENABLE_PRINT();
 
         return Result::SUCCESS;

--- a/benchmarks/modules/cast/generic.hh
+++ b/benchmarks/modules/cast/generic.hh
@@ -107,7 +107,7 @@ protected:
         BL_DISABLE_PRINT();
         Create(module, config, {
             .buf = deviceInputBuf, 
-        });
+        }, this->getStream());
         BL_ENABLE_PRINT();
 
         return Result::SUCCESS;

--- a/benchmarks/modules/channelizer/generic.cc
+++ b/benchmarks/modules/channelizer/generic.cc
@@ -1,4 +1,4 @@
-#include "blade/modules/channelizer.hh"
+#include "blade/modules/channelizer/base.hh"
 
 #include "./generic.hh"
 

--- a/benchmarks/modules/channelizer/generic.cc
+++ b/benchmarks/modules/channelizer/generic.cc
@@ -12,8 +12,6 @@ static void BM_Channelizer_Compute(bm::State& state) {
 
 BENCHMARK(BM_Channelizer_Compute)
     ->Iterations(2<<13)
-    ->Args({16, 4})
-    ->Args({16, 64})
     ->Args({16, 8192})
     ->UseManualTime()
     ->Unit(bm::kMillisecond);
@@ -25,7 +23,6 @@ static void BM_Channelizer_Transfer(bm::State& state) {
 
 BENCHMARK(BM_Channelizer_Transfer)
     ->Iterations(64)
-    ->Args({16, 4})
     ->Args({16, 8192})
     ->UseManualTime()
     ->Unit(bm::kMillisecond);
@@ -37,8 +34,6 @@ static void BM_Channelizer_Converged(bm::State& state) {
 
 BENCHMARK(BM_Channelizer_Converged)
     ->Iterations(64)
-    ->Args({16, 4})
-    ->Args({16, 64})
     ->Args({16, 8192})
     ->UseManualTime()
     ->Unit(bm::kMillisecond);

--- a/benchmarks/modules/channelizer/generic.hh
+++ b/benchmarks/modules/channelizer/generic.hh
@@ -110,7 +110,7 @@ protected:
         BL_DISABLE_PRINT();
         Create(module, config, {
             .buf = deviceInputBuf, 
-        });
+        }, this->getStream());
         BL_ENABLE_PRINT();
 
         return Result::SUCCESS;

--- a/benchmarks/modules/detector/generic.hh
+++ b/benchmarks/modules/detector/generic.hh
@@ -113,7 +113,7 @@ protected:
         BL_DISABLE_PRINT();
         Create(module, config, {
             .buf = deviceInputBuf, 
-        });
+        }, this->getStream());
         BL_ENABLE_PRINT();
 
         return Result::SUCCESS;

--- a/benchmarks/modules/polarizer/generic.hh
+++ b/benchmarks/modules/polarizer/generic.hh
@@ -112,7 +112,7 @@ protected:
         BL_DISABLE_PRINT();
         Create(module, config, {
             .buf = deviceInputBuf, 
-        });
+        }, this->getStream());
         BL_ENABLE_PRINT();
 
         return Result::SUCCESS;

--- a/include/blade/macros.hh
+++ b/include/blade/macros.hh
@@ -6,6 +6,17 @@
 
 namespace Blade {
 
+enum class MemoryTaint : uint8_t {
+    NONE     = 0 << 0,
+    CONSUMER = 1 << 0,
+    PRODUCER = 1 << 1,
+    MODIFIER = 1 << 2,
+};
+
+inline constexpr const MemoryTaint operator|(MemoryTaint lhs, MemoryTaint rhs) {
+    return static_cast<MemoryTaint>(static_cast<uint8_t>(lhs) | static_cast<uint8_t>(rhs));
+}
+
 enum class Result : uint8_t {
     SUCCESS = 0,
     ERROR = 1,

--- a/include/blade/macros.hh
+++ b/include/blade/macros.hh
@@ -13,7 +13,7 @@ enum class MemoryTaint : uint8_t {
     MODIFIER = 1 << 2,
 };
 
-inline const MemoryTaint operator|(MemoryTaint lhs, MemoryTaint rhs) {
+inline constexpr MemoryTaint operator|(MemoryTaint lhs, MemoryTaint rhs) {
     return static_cast<MemoryTaint>(static_cast<uint8_t>(lhs) | static_cast<uint8_t>(rhs));
 }
 

--- a/include/blade/macros.hh
+++ b/include/blade/macros.hh
@@ -62,6 +62,16 @@ enum class Result : uint8_t {
 }
 #endif
 
+#ifndef BL_CUDA_CHECK_KERNEL_THROW
+#define BL_CUDA_CHECK_KERNEL_THROW(callback) { \
+    cudaError_t val; \
+    if ((val = cudaPeekAtLastError()) != cudaSuccess) { \
+        auto err = cudaGetErrorString(val); \
+        throw callback(); \
+    } \
+}
+#endif
+
 #ifndef BL_CUDA_CHECK
 #define BL_CUDA_CHECK(x, callback) { \
     cudaError_t val = (x); \

--- a/include/blade/macros.hh
+++ b/include/blade/macros.hh
@@ -13,7 +13,7 @@ enum class MemoryTaint : uint8_t {
     MODIFIER = 1 << 2,
 };
 
-inline constexpr const MemoryTaint operator|(MemoryTaint lhs, MemoryTaint rhs) {
+inline const MemoryTaint operator|(MemoryTaint lhs, MemoryTaint rhs) {
     return static_cast<MemoryTaint>(static_cast<uint8_t>(lhs) | static_cast<uint8_t>(rhs));
 }
 

--- a/include/blade/macros.hh
+++ b/include/blade/macros.hh
@@ -94,6 +94,26 @@ enum class Result : uint8_t {
 }
 #endif
 
+#ifndef BL_CUFFT_CHECK
+#define BL_CUFFT_CHECK(x, callback) { \
+    cufftResult err = (x); \
+    if (err != CUFFT_SUCCESS) { \
+        callback(); \
+        return Result::CUDA_ERROR; \
+    } \
+}
+#endif
+
+#ifndef BL_CUFFT_CHECK_THROW
+#define BL_CUFFT_CHECK_THROW(x, callback) { \
+    cufftResult err = (x); \
+    if (err != CUFFT_SUCCESS) { \
+        callback(); \
+        throw Result::CUDA_ERROR; \
+    } \
+}
+#endif
+
 #ifndef BL_CHECK
 #define BL_CHECK(x) { \
     Result val = (x); \

--- a/include/blade/memory/types.hh
+++ b/include/blade/memory/types.hh
@@ -23,7 +23,7 @@ enum class BLADE_API Device : uint8_t {
     VULKAN  = 1 << 3,
 };
 
-inline constexpr const Device operator|(Device lhs, Device rhs) {
+inline constexpr Device operator|(Device lhs, Device rhs) {
     return static_cast<Device>(static_cast<uint8_t>(lhs) | static_cast<uint8_t>(rhs));
 }
 
@@ -289,7 +289,7 @@ class Dimensions : public std::vector<U64> {
  public:
     using std::vector<U64>::vector;
 
-    const U64 size() const {
+    U64 size() const {
         U64 size = 1;
         for (const auto& n : *this) {
             size *= n;

--- a/include/blade/memory/types.hh
+++ b/include/blade/memory/types.hh
@@ -23,7 +23,7 @@ enum class BLADE_API Device : uint8_t {
     VULKAN  = 1 << 3,
 };
 
-inline const Device operator|(Device lhs, Device rhs) {
+inline constexpr const Device operator|(Device lhs, Device rhs) {
     return static_cast<Device>(static_cast<uint8_t>(lhs) | static_cast<uint8_t>(rhs));
 }
 

--- a/include/blade/memory/types.hh
+++ b/include/blade/memory/types.hh
@@ -23,7 +23,7 @@ enum class BLADE_API Device : uint8_t {
     VULKAN  = 1 << 3,
 };
 
-inline constexpr const Device operator|(Device lhs, Device rhs) {
+inline const Device operator|(Device lhs, Device rhs) {
     return static_cast<Device>(static_cast<uint8_t>(lhs) | static_cast<uint8_t>(rhs));
 }
 

--- a/include/blade/memory/vector.hh
+++ b/include/blade/memory/vector.hh
@@ -90,7 +90,7 @@ class VectorImpl {
         return container.end();
     }
 
-    const Result link(const VectorImpl<Type, Dims>& src) {
+    const Result link(const VectorImpl<Type, Dims>& src, Dims dstDims) {
         if (src.empty()) {
             BL_FATAL("Source can't be empty while linking.");
             return Result::ERROR;
@@ -101,11 +101,21 @@ class VectorImpl {
             return Result::ERROR;
         }
 
+        if (src.dims().size() != dstDims.size()) { 
+            BL_FATAL("Dimensions mismatch. The number of elements of "
+                     "the source and destination has to be the same.");
+            return Result::ERROR;
+        }
+
         this->managed = false;
         this->container = src.span();
-        this->dimensions = src.dims();
+        this->dimensions = dstDims;
 
         return Result::SUCCESS;
+    }
+
+    const Result link(const VectorImpl<Type, Dims>& src) {
+        return link(src, src.dims());
     }
 
     virtual const Result resize(const Dims& dims) = 0;

--- a/include/blade/module.hh
+++ b/include/blade/module.hh
@@ -21,6 +21,10 @@ class Module {
         : cache(100, *program) {};
     virtual ~Module() = default;
 
+    virtual constexpr const MemoryTaint getMemoryTaint() {
+        return MemoryTaint::NONE; 
+    }
+
     virtual constexpr const Result preprocess(const cudaStream_t& stream, 
                                               const U64& currentComputeCount) {
         return Result::SUCCESS;

--- a/include/blade/modules/base.hh
+++ b/include/blade/modules/base.hh
@@ -8,7 +8,7 @@
 #endif
 
 #ifdef BLADE_MODULE_CHANNELIZER
-#include "blade/modules/channelizer.hh"
+#include "blade/modules/channelizer/base.hh"
 #endif
 
 #ifdef BLADE_MODULE_DETECTOR

--- a/include/blade/modules/beamformer/ata.hh
+++ b/include/blade/modules/beamformer/ata.hh
@@ -9,7 +9,8 @@ template<typename IT, typename OT>
 class BLADE_API ATA : public Generic<IT, OT> {
  public:
     explicit ATA(const typename Generic<IT, OT>::Config& config,
-                 const typename Generic<IT, OT>::Input& input);
+                 const typename Generic<IT, OT>::Input& input,
+                 const cudaStream_t& stream);
 
  protected:
     const ArrayDimensions getOutputBufferDims() const {

--- a/include/blade/modules/beamformer/generic.hh
+++ b/include/blade/modules/beamformer/generic.hh
@@ -58,7 +58,8 @@ class BLADE_API Generic : public Module {
 
     // Constructor & Processing 
 
-    explicit Generic(const Config& config, const Input& input);
+    explicit Generic(const Config& config, const Input& input,
+                     const cudaStream_t& stream);
     virtual ~Generic() = default;
     const Result process(const cudaStream_t& stream) final;
 

--- a/include/blade/modules/beamformer/generic.hh
+++ b/include/blade/modules/beamformer/generic.hh
@@ -49,6 +49,13 @@ class BLADE_API Generic : public Module {
         return this->output.buf;
     }
 
+    // Taint Registers
+
+    constexpr const MemoryTaint getMemoryTaint() {
+        return MemoryTaint::CONSUMER | 
+               MemoryTaint::PRODUCER;
+    }
+
     // Constructor & Processing 
 
     explicit Generic(const Config& config, const Input& input);

--- a/include/blade/modules/beamformer/meerkat.hh
+++ b/include/blade/modules/beamformer/meerkat.hh
@@ -9,7 +9,8 @@ template<typename IT, typename OT>
 class BLADE_API MeerKAT : public Generic<IT, OT> {
  public:
     explicit MeerKAT(const typename Generic<IT, OT>::Config& config,
-                     const typename Generic<IT, OT>::Input& input);
+                     const typename Generic<IT, OT>::Input& input,
+                     const cudaStream_t& stream);
 
  protected:
     const ArrayDimensions getOutputBufferDims() const {

--- a/include/blade/modules/bfr5/reader.hh
+++ b/include/blade/modules/bfr5/reader.hh
@@ -35,6 +35,12 @@ class BLADE_API Reader : public Module {
     struct Output {
     };
 
+    // Taint Registers
+
+    constexpr const MemoryTaint getMemoryTaint() {
+        return MemoryTaint::NONE; 
+    }
+
     // Constructor & Processing
 
     explicit Reader(const Config& config, const Input& input);

--- a/include/blade/modules/bfr5/reader.hh
+++ b/include/blade/modules/bfr5/reader.hh
@@ -43,7 +43,8 @@ class BLADE_API Reader : public Module {
 
     // Constructor & Processing
 
-    explicit Reader(const Config& config, const Input& input);
+    explicit Reader(const Config& config, const Input& input,
+                    const cudaStream_t& stream);
 
     // Miscellaneous
 

--- a/include/blade/modules/cast.hh
+++ b/include/blade/modules/cast.hh
@@ -39,6 +39,13 @@ class BLADE_API Cast : public Module {
         return this->output.buf;
     }
 
+    // Taint Registers
+
+    constexpr const MemoryTaint getMemoryTaint() {
+        return MemoryTaint::CONSUMER |
+               MemoryTaint::PRODUCER;
+    }
+
     // Constructor & Processing
 
     explicit Cast(const Config& config, const Input& input);

--- a/include/blade/modules/cast.hh
+++ b/include/blade/modules/cast.hh
@@ -48,7 +48,8 @@ class BLADE_API Cast : public Module {
 
     // Constructor & Processing
 
-    explicit Cast(const Config& config, const Input& input);
+    explicit Cast(const Config& config, const Input& input, 
+                  const cudaStream_t& stream);
     const Result process(const cudaStream_t& stream) final;
 
  private:

--- a/include/blade/modules/channelizer/base.hh
+++ b/include/blade/modules/channelizer/base.hh
@@ -1,11 +1,13 @@
-#ifndef BLADE_MODULES_CHANNELIZER_HH
-#define BLADE_MODULES_CHANNELIZER_HH
+#ifndef BLADE_MODULES_CHANNELIZER_BASE_HH
+#define BLADE_MODULES_CHANNELIZER_BASE_HH
 
 #include <string>
 #include <cufft.h>
 
 #include "blade/base.hh"
 #include "blade/module.hh"
+
+#include "blade/modules/channelizer/callback.hh"
 
 namespace Blade::Modules {
 
@@ -68,6 +70,7 @@ class BLADE_API Channelizer : public Module {
 
     cufftHandle plan;
     std::string kernel_key;
+    std::unique_ptr<Internal::Callback> callback;
 
     // Expected Dimensions
 

--- a/include/blade/modules/channelizer/base.hh
+++ b/include/blade/modules/channelizer/base.hh
@@ -46,6 +46,13 @@ class BLADE_API Channelizer : public Module {
         return this->output.buf;
     }
 
+    // Taint Registers
+
+    constexpr const MemoryTaint getMemoryTaint() {
+        return MemoryTaint::CONSUMER |
+               MemoryTaint::PRODUCER;
+    }
+
     // Constructor & Processing
 
     explicit Channelizer(const Config& config, const Input& input);

--- a/include/blade/modules/channelizer/base.hh
+++ b/include/blade/modules/channelizer/base.hh
@@ -55,7 +55,8 @@ class BLADE_API Channelizer : public Module {
 
     // Constructor & Processing
 
-    explicit Channelizer(const Config& config, const Input& input);
+    explicit Channelizer(const Config& config, const Input& input, 
+                         const cudaStream_t& stream);
     const Result process(const cudaStream_t& stream) final;
     ~Channelizer();
 

--- a/include/blade/modules/channelizer/base.hh
+++ b/include/blade/modules/channelizer/base.hh
@@ -59,9 +59,6 @@ class BLADE_API Channelizer : public Module {
     const Input input;
     Output output;
 
-    std::string pre_kernel;
-    dim3 pre_grid, pre_block;
-
     std::string post_kernel;
     dim3 post_grid, post_block;
 

--- a/include/blade/modules/channelizer/callback.hh
+++ b/include/blade/modules/channelizer/callback.hh
@@ -5,6 +5,7 @@
 #include <cufft.h>
 #include <cufftXt.h>
 
+#include "blade/memory/types.hh"
 #include "blade/logger.hh"
 #include "blade/macros.hh"
 
@@ -13,10 +14,12 @@ namespace Internal {
 
 class Callback {
  public:
-    Callback(cufftHandle& plan);
+    Callback(cufftHandle& plan, const U64& numberOfPolarizations);
+    ~Callback();
 
  private:
     cufftCallbackLoadC h_loadCallbackPtr;
+    U64* callerInfo;
 };
 
 }  // namespace Internal

--- a/include/blade/modules/channelizer/callback.hh
+++ b/include/blade/modules/channelizer/callback.hh
@@ -1,0 +1,25 @@
+#ifndef BLADE_MODULES_CHANNELIZER_CALLBACK_HH
+#define BLADE_MODULES_CHANNELIZER_CALLBACK_HH
+
+#include <cuda_runtime.h>
+#include <cufft.h>
+#include <cufftXt.h>
+
+#include "blade/logger.hh"
+#include "blade/macros.hh"
+
+namespace Blade {
+namespace Internal {
+
+class Callback {
+ public:
+    Callback(cufftHandle& plan);
+
+ private:
+    cufftCallbackLoadC h_loadCallbackPtr;
+};
+
+}  // namespace Internal
+}  // namespace Blade
+
+#endif

--- a/include/blade/modules/detector.hh
+++ b/include/blade/modules/detector.hh
@@ -44,6 +44,13 @@ class BLADE_API Detector : public Module {
         return this->output.buf;
     }
 
+    // Taint Registers
+
+    constexpr const MemoryTaint getMemoryTaint() {
+        return MemoryTaint::CONSUMER | 
+               MemoryTaint::PRODUCER;
+    }
+
     // Constructor & Processing
 
     explicit Detector(const Config& config, const Input& input);

--- a/include/blade/modules/detector.hh
+++ b/include/blade/modules/detector.hh
@@ -53,7 +53,8 @@ class BLADE_API Detector : public Module {
 
     // Constructor & Processing
 
-    explicit Detector(const Config& config, const Input& input);
+    explicit Detector(const Config& config, const Input& input, 
+                      const cudaStream_t& stream);
     const Result preprocess(const cudaStream_t& stream, const U64& currentComputeCount) final;
     const Result process(const cudaStream_t& stream) final;
 

--- a/include/blade/modules/guppi/reader.hh
+++ b/include/blade/modules/guppi/reader.hh
@@ -88,7 +88,8 @@ class BLADE_API Reader : public Module {
 
     // Constructor & Processing
 
-    explicit Reader(const Config& config, const Input& input);
+    explicit Reader(const Config& config, const Input& input, 
+                    const cudaStream_t& stream);
     const Result preprocess(const cudaStream_t& stream, const U64& currentComputeCount) final;
 
     // Miscellaneous 

--- a/include/blade/modules/guppi/reader.hh
+++ b/include/blade/modules/guppi/reader.hh
@@ -80,6 +80,12 @@ class BLADE_API Reader : public Module {
                this->getStepOutputBufferDims().size();
     }
 
+    // Taint Registers
+
+    constexpr const MemoryTaint getMemoryTaint() {
+        return MemoryTaint::PRODUCER; 
+    }
+
     // Constructor & Processing
 
     explicit Reader(const Config& config, const Input& input);

--- a/include/blade/modules/guppi/writer.hh
+++ b/include/blade/modules/guppi/writer.hh
@@ -46,6 +46,12 @@ class BLADE_API Writer : public Module {
     struct Output {
     };
 
+    // Taint Registers
+
+    constexpr const MemoryTaint getMemoryTaint() {
+        return MemoryTaint::CONSUMER; 
+    }
+
     // Constructor & Processing
 
     explicit Writer(const Config& config, const Input& input);

--- a/include/blade/modules/guppi/writer.hh
+++ b/include/blade/modules/guppi/writer.hh
@@ -54,7 +54,8 @@ class BLADE_API Writer : public Module {
 
     // Constructor & Processing
 
-    explicit Writer(const Config& config, const Input& input);
+    explicit Writer(const Config& config, const Input& input,
+                    const cudaStream_t& stream);
     const Result preprocess(const cudaStream_t& stream, const U64& currentComputeCount) final;
 
     // Miscullaneous

--- a/include/blade/modules/phasor/ata.hh
+++ b/include/blade/modules/phasor/ata.hh
@@ -9,7 +9,8 @@ template<typename OT>
 class BLADE_API ATA : public Generic<OT> {
  public:
     explicit ATA(const typename Generic<OT>::Config& config,
-                 const typename Generic<OT>::Input& input);
+                 const typename Generic<OT>::Input& input,
+                 const cudaStream_t& stream);
 
     const Result preprocess(const cudaStream_t& stream, const U64& currentComputeCount) final;
 

--- a/include/blade/modules/phasor/generic.hh
+++ b/include/blade/modules/phasor/generic.hh
@@ -65,6 +65,13 @@ class BLADE_API Generic : public Module {
         return this->output.phasors;
     } 
 
+    // Taint Registers
+
+    constexpr const MemoryTaint getMemoryTaint() {
+        return MemoryTaint::CONSUMER |
+               MemoryTaint::PRODUCER; 
+    }
+
     // Constructor & Processing
 
     explicit Generic(const Config& config, const Input& input);

--- a/include/blade/modules/phasor/generic.hh
+++ b/include/blade/modules/phasor/generic.hh
@@ -74,7 +74,8 @@ class BLADE_API Generic : public Module {
 
     // Constructor & Processing
 
-    explicit Generic(const Config& config, const Input& input);
+    explicit Generic(const Config& config, const Input& input, 
+                     const cudaStream_t& stream);
     virtual ~Generic() = default;
     virtual const Result preprocess(const cudaStream_t& stream, const U64& currentComputeCount) = 0;
 

--- a/include/blade/modules/polarizer.hh
+++ b/include/blade/modules/polarizer.hh
@@ -45,6 +45,12 @@ class BLADE_API Polarizer : public Module {
         return this->output.buf;
     }
 
+    // Taint Registers
+
+    constexpr const MemoryTaint getMemoryTaint() {
+        return MemoryTaint::MODIFIER;
+    }
+
     // Constructor & Processing
 
     explicit Polarizer(const Config& config, const Input& input);

--- a/include/blade/modules/polarizer.hh
+++ b/include/blade/modules/polarizer.hh
@@ -53,7 +53,8 @@ class BLADE_API Polarizer : public Module {
 
     // Constructor & Processing
 
-    explicit Polarizer(const Config& config, const Input& input);
+    explicit Polarizer(const Config& config, const Input& input,
+                       const cudaStream_t& stream);
     const Result process(const cudaStream_t& stream) final;
 
  private:

--- a/include/blade/pipeline.hh
+++ b/include/blade/pipeline.hh
@@ -49,7 +49,7 @@ class BLADE_API Pipeline {
     void connect(std::shared_ptr<Block>& module,
                  const typename Block::Config& config,
                  const typename Block::Input& input) {
-        module = std::make_unique<Block>(config, input);
+        module = std::make_unique<Block>(config, input, stream);
         this->modules.push_back(module);
     }
 

--- a/include/blade/pipelines/ata/mode_b.hh
+++ b/include/blade/pipelines/ata/mode_b.hh
@@ -7,7 +7,7 @@
 #include "blade/pipeline.hh"
 
 #include "blade/modules/cast.hh"
-#include "blade/modules/channelizer.hh"
+#include "blade/modules/channelizer/base.hh"
 #include "blade/modules/beamformer/ata.hh"
 #include "blade/modules/phasor/ata.hh"
 #include "blade/modules/polarizer.hh"

--- a/include/blade/pipelines/generic/mode_h.hh
+++ b/include/blade/pipelines/generic/mode_h.hh
@@ -6,7 +6,7 @@
 
 #include "blade/pipeline.hh"
 
-#include "blade/modules/channelizer.hh"
+#include "blade/modules/channelizer/base.hh"
 #include "blade/modules/detector.hh"
 #include "blade/modules/cast.hh"
 #include "blade/modules/polarizer.hh"

--- a/meson.build
+++ b/meson.build
@@ -35,6 +35,7 @@ lib_blade = library(
     include_directories: inc_lst,
     dependencies: dep_lst + static_dep_lst,
     gnu_symbol_visibility: 'hidden',
+    cuda_args: ['-dc'],
     install: true,
 )
 

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
     'blade',
     ['cpp', 'c', 'cuda'],
-    version: '0.7.8',
+    version: '0.8.0',
     default_options: [
         'buildtype=release',
         'cpp_std=c++20',

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
     'blade',
     ['cpp', 'c', 'cuda'],
-    version: '0.7.7',
+    version: '0.7.8',
     default_options: [
         'buildtype=release',
         'cpp_std=c++20',
@@ -12,8 +12,11 @@ project(
 cfg_lst = configuration_data()
 src_lst = []
 dep_lst = [
-    dependency('cuda', version : '>=11', modules : ['nvrtc', 'cudart', 'cuda', 'cufft']),
+    dependency('cuda', version : '>=11', modules : ['nvrtc', 'cudart', 'cuda', 'culibos']),
     dependency('fmt'),
+]
+static_dep_lst = [
+    dependency('cuda', version : '>=11', modules : ['cufft_static']),
 ]
 inc_lst = [
     include_directories('include'),
@@ -30,7 +33,7 @@ lib_blade = library(
     'blade',
     src_lst,
     include_directories: inc_lst,
-    dependencies: dep_lst,
+    dependencies: dep_lst + static_dep_lst,
     gnu_symbol_visibility: 'hidden',
     install: true,
 )

--- a/python/modules.hh
+++ b/python/modules.hh
@@ -29,9 +29,6 @@ inline void init_ata_beamformer(const py::module& m) {
                                                                   py::arg("phasors"));
 
     beamformer
-        .def(py::init<const Class::Config&,
-                      const Class::Input&>(), py::arg("config"),
-                                              py::arg("input"))
         .def("input", &Class::getInputBuffer, py::return_value_policy::reference)
         .def("phasors", &Class::getInputPhasors, py::return_value_policy::reference)
         .def("output", &Class::getOutputBuffer, py::return_value_policy::reference);
@@ -81,9 +78,6 @@ inline void init_ata_phasor(const py::module& m) {
                                                           py::arg("block_dut1"));
 
     phasor
-        .def(py::init<const Class::Config&,
-                      const Class::Input&>(), py::arg("config"),
-                                              py::arg("input"))
         .def("delays", &Class::getOutputDelays, py::return_value_policy::reference)
         .def("phasors", &Class::getOutputPhasors, py::return_value_policy::reference);
 }
@@ -106,9 +100,6 @@ inline void init_channelizer(const py::module& m) {
         .def(py::init<const ArrayTensor<Device::CUDA, CF32>&>(), py::arg("buf"));
 
     channelizer
-        .def(py::init<const Class::Config&,
-                      const Class::Input&>(), py::arg("config"),
-                                              py::arg("input"))
         .def("input", &Class::getInputBuffer, py::return_value_policy::reference)
         .def("output", &Class::getOutputBuffer, py::return_value_policy::reference);
 }
@@ -133,9 +124,6 @@ inline void init_detector(const py::module& m) {
         .def(py::init<const ArrayTensor<Device::CUDA, CF32>&>(), py::arg("buf"));
         
     detector
-        .def(py::init<const Class::Config&,
-                      const Class::Input&>(), py::arg("config"),
-                                              py::arg("input"))
         .def("input", &Class::getInputBuffer, py::return_value_policy::reference)
         .def("output", &Class::getOutputBuffer, py::return_value_policy::reference);
 }
@@ -163,9 +151,6 @@ inline void init_polarizer(const py::module& m) {
         .def(py::init<const ArrayTensor<Device::CUDA, CF32>&>(), py::arg("buf"));
         
     polarizer
-        .def(py::init<const Class::Config&,
-                      const Class::Input&>(), py::arg("config"),
-                                              py::arg("input"))
         .def("input", &Class::getInputBuffer, py::return_value_policy::reference)
         .def("output", &Class::getOutputBuffer, py::return_value_policy::reference);
 }

--- a/src/modules/beamformer/ata.cc
+++ b/src/modules/beamformer/ata.cc
@@ -6,8 +6,9 @@ namespace Blade::Modules::Beamformer {
 
 template<typename IT, typename OT>
 ATA<IT, OT>::ATA(const typename Generic<IT, OT>::Config& config,
-                 const typename Generic<IT, OT>::Input& input)
-        : Generic<IT, OT>(config, input) {
+                 const typename Generic<IT, OT>::Input& input,
+                 const cudaStream_t& stream)
+        : Generic<IT, OT>(config, input, stream) {
     // Check configuration values.
     if (this->getInputPhasors().dims().numberOfBeams() > config.blockSize) {
         BL_FATAL("The block size ({}) is smaller than the number of beams ({}).", 

--- a/src/modules/beamformer/generic.cc
+++ b/src/modules/beamformer/generic.cc
@@ -7,7 +7,9 @@
 namespace Blade::Modules::Beamformer {
 
 template<typename IT, typename OT>
-Generic<IT, OT>::Generic(const Config& config, const Input& input)
+Generic<IT, OT>::Generic(const Config& config, 
+                         const Input& input,
+                         const cudaStream_t& stream)
         : Module(beamformer_program),
           config(config),
           input(input) {

--- a/src/modules/beamformer/meerkat.cc
+++ b/src/modules/beamformer/meerkat.cc
@@ -6,8 +6,9 @@ namespace Blade::Modules::Beamformer {
 
 template<typename IT, typename OT>
 MeerKAT<IT, OT>::MeerKAT(const typename Generic<IT, OT>::Config& config,
-                         const typename Generic<IT, OT>::Input& input)
-        : Generic<IT, OT>(config, input) {
+                         const typename Generic<IT, OT>::Input& input, 
+                         const cudaStream_t& stream)
+        : Generic<IT, OT>(config, input, stream) {
     // Configure kernels.
     BL_CHECK_THROW(
         this->createKernel(

--- a/src/modules/bfr5/base.cc
+++ b/src/modules/bfr5/base.cc
@@ -6,7 +6,9 @@
 
 namespace Blade::Modules::Bfr5 {
 
-Reader::Reader(const Config& config, const Input& input) 
+Reader::Reader(const Config& config,
+               const Input& input,
+               const cudaStream_t& stream) 
         : Module(bfr5_program),
           config(config),
           input(input) {

--- a/src/modules/cast/base.cc
+++ b/src/modules/cast/base.cc
@@ -10,7 +10,9 @@
 namespace Blade::Modules {
 
 template<typename IT, typename OT>
-Cast<IT, OT>::Cast(const Config& config, const Input& input)
+Cast<IT, OT>::Cast(const Config& config,
+                   const Input& input,
+                   const cudaStream_t& stream)
         : Module(cast_program),
           config(config),
           input(input) {

--- a/src/modules/channelizer/base.cc
+++ b/src/modules/channelizer/base.cc
@@ -53,6 +53,9 @@ Channelizer<IT, OT>::Channelizer(const Config& config,
     if (config.rate != 4) {
         BL_INFO("FFT Backend: cuFFT");
 
+        // Setup cuFFT stream.
+        cufftSetStream(plan, stream);
+
         // FFT dimension (1D, 2D, ...).
         int rank = 1;
 
@@ -186,8 +189,6 @@ const Result Channelizer<IT, OT>::process(const cudaStream_t& stream) {
     } 
 
     if (config.rate != 4) {
-        cufftSetStream(plan, stream);
-
         cufftComplex* input_ptr = reinterpret_cast<cufftComplex*>(input.buf.data()); 
         cufftComplex* output_ptr = reinterpret_cast<cufftComplex*>(buffer.data()); 
 

--- a/src/modules/channelizer/base.cc
+++ b/src/modules/channelizer/base.cc
@@ -1,6 +1,6 @@
 #define BL_LOG_DOMAIN "M::CHANNELIZER"
 
-#include "blade/modules/channelizer.hh"
+#include "blade/modules/channelizer/base.hh"
 
 #include "channelizer.jit.hh"
 
@@ -78,6 +78,9 @@ Channelizer<IT, OT>::Channelizer(const Config& config, const Input& input)
                       inembed, istride, idist,
                       onembed, ostride, odist,
                       CUFFT_C2C, batch);
+
+        // Install callbacks.
+        callback = std::make_unique<Internal::Callback>(plan);
 
         // Perform FFT shift before cuFFT.
         BL_CHECK_THROW(

--- a/src/modules/channelizer/base.cc
+++ b/src/modules/channelizer/base.cc
@@ -186,7 +186,7 @@ const Result Channelizer<IT, OT>::process(const cudaStream_t& stream) {
     if (config.rate != 4) {
         cufftSetStream(plan, stream);
 
-        cufftComplex* input_ptr = reinterpret_cast<cufftComplex*>(input.buf.data()); 
+        cufftComplex* input_ptr = reinterpret_cast<cufftComplex*>(output.buf.data()); 
         cufftComplex* output_ptr = reinterpret_cast<cufftComplex*>(buffer.data()); 
 
         if (config.rate == getInputBuffer().dims().numberOfTimeSamples()) {
@@ -203,6 +203,11 @@ const Result Channelizer<IT, OT>::process(const cudaStream_t& stream) {
     } else {
         BL_CHECK(runKernel("internal", stream, input.buf.data(), output.buf.data()));
     }
+
+    BL_CUDA_CHECK_KERNEL([&]{
+        BL_FATAL("Module failed to execute: {}", err);
+        return Result::CUDA_ERROR;
+    });
 
     return Result::SUCCESS;
 }

--- a/src/modules/channelizer/base.cc
+++ b/src/modules/channelizer/base.cc
@@ -7,7 +7,9 @@
 namespace Blade::Modules {
 
 template<typename IT, typename OT>
-Channelizer<IT, OT>::Channelizer(const Config& config, const Input& input)
+Channelizer<IT, OT>::Channelizer(const Config& config, 
+                                 const Input& input,
+                                 const cudaStream_t& stream)
         : Module(channelizer_program),
           config(config),
           input(input),

--- a/src/modules/channelizer/callback.cu
+++ b/src/modules/channelizer/callback.cu
@@ -14,17 +14,11 @@ __device__ cufftComplex CB_ConvertInputC(void *dataIn, size_t offset, void *call
     return element;
 }
 
-__device__ cufftCallbackLoadC d_loadCallbackPtr = CB_ConvertInputC; 
+__managed__ __device__ cufftCallbackLoadC d_loadCallbackPtr = CB_ConvertInputC; 
 
 Callback::Callback(cufftHandle& plan) {
-    BL_CUDA_CHECK_THROW(cudaMemcpyFromSymbol(&h_loadCallbackPtr, 
-                                             d_loadCallbackPtr, 
-                                             sizeof(h_loadCallbackPtr)), [&]{
-        BL_FATAL("The allocation of an cuFFT callback failed: {}", err);
-    });
-
     BL_CUFFT_CHECK_THROW(cufftXtSetCallback(plan, 
-                                            (void**)&h_loadCallbackPtr, 
+                                            (void**)&d_loadCallbackPtr, 
                                             CUFFT_CB_LD_COMPLEX,
                                             0), [&]{
         BL_FATAL("The configuration of an cuFFT callback failed: {0:#x}", err);

--- a/src/modules/channelizer/callback.cu
+++ b/src/modules/channelizer/callback.cu
@@ -4,9 +4,10 @@ namespace Blade {
 namespace Internal {
 
 __device__ cufftComplex CB_ConvertInputC(void *dataIn, size_t offset, void *callerInfo, void *sharedPtr) {
-    auto& element = static_cast<cufftComplex*>(dataIn)[offset];
+    const auto& numberOfPolarizations = static_cast<U64*>(callerInfo)[0];
+    auto element = static_cast<cufftComplex*>(dataIn)[offset];
 
-    if ((offset % 2) != 0){
+    if (((offset / numberOfPolarizations) % 2) != 0){
         element.x = -element.x;
         element.y = -element.y;
     }
@@ -16,11 +17,16 @@ __device__ cufftComplex CB_ConvertInputC(void *dataIn, size_t offset, void *call
 
 __managed__ __device__ cufftCallbackLoadC d_loadCallbackPtr = CB_ConvertInputC; 
 
-Callback::Callback(cufftHandle& plan) {
+Callback::Callback(cufftHandle& plan, const U64& numberOfPolarizations) {
+    BL_CUDA_CHECK_THROW(cudaMallocManaged(&callerInfo, sizeof(U64)), [&]{
+        BL_FATAL("Can't allocate CUDA memory: {}", err);
+    });
+    this->callerInfo[0] = static_cast<U64>(numberOfPolarizations);
+
     BL_CUFFT_CHECK_THROW(cufftXtSetCallback(plan, 
                                             (void**)&d_loadCallbackPtr, 
                                             CUFFT_CB_LD_COMPLEX,
-                                            0), [&]{
+                                            (void**)&callerInfo), [&]{
         BL_FATAL("The configuration of an cuFFT callback failed: {0:#x}", err);
     });
 
@@ -28,6 +34,12 @@ Callback::Callback(cufftHandle& plan) {
         BL_FATAL("Callbacks failed to install: {}", err);
         return Result::CUDA_ERROR;
     });
+}
+
+Callback::~Callback() {
+    if (callerInfo) {
+        cudaFree(callerInfo);
+    }
 }
 
 }  // namespace Internal

--- a/src/modules/channelizer/callback.cu
+++ b/src/modules/channelizer/callback.cu
@@ -3,11 +3,37 @@
 namespace Blade {
 namespace Internal {
 
-__device__ cufftComplex CB_ConvertInputC(void *dataIn, size_t offset, void *callerInfo, void *sharedPtr) {
-    const auto& numberOfPolarizations = static_cast<U64*>(callerInfo)[0];
+__device__ cufftComplex CB_ConvertInputC_2POL(void *dataIn, size_t offset, void *callerInfo, void *sharedPtr) {
     auto element = static_cast<cufftComplex*>(dataIn)[offset];
 
-    if (((offset / numberOfPolarizations) % 2) != 0){
+    if ((offset % 4) != 0){
+        element.x = -element.x;
+        element.y = -element.y;
+    }
+
+    return element;
+}
+
+__managed__ __device__ cufftCallbackLoadC d_2POL_loadCallbackPtr = CB_ConvertInputC_2POL; 
+
+__device__ cufftComplex CB_ConvertInputC_1POL(void *dataIn, size_t offset, void *callerInfo, void *sharedPtr) {
+    auto element = static_cast<cufftComplex*>(dataIn)[offset];
+
+    if ((offset % 2) != 0){
+        element.x = -element.x;
+        element.y = -element.y;
+    }
+
+    return element;
+}
+
+__managed__ __device__ cufftCallbackLoadC d_1POL_loadCallbackPtr = CB_ConvertInputC_1POL; 
+
+__device__ cufftComplex CB_ConvertInputC(void *dataIn, size_t offset, void *callerInfo, void *sharedPtr) {
+    const auto& inverseStride = static_cast<U64*>(callerInfo)[0];
+    auto element = static_cast<cufftComplex*>(dataIn)[offset];
+
+    if ((offset % inverseStride) != 0){
         element.x = -element.x;
         element.y = -element.y;
     }
@@ -18,15 +44,27 @@ __device__ cufftComplex CB_ConvertInputC(void *dataIn, size_t offset, void *call
 __managed__ __device__ cufftCallbackLoadC d_loadCallbackPtr = CB_ConvertInputC; 
 
 Callback::Callback(cufftHandle& plan, const U64& numberOfPolarizations) {
-    BL_CUDA_CHECK_THROW(cudaMallocManaged(&callerInfo, sizeof(U64)), [&]{
-        BL_FATAL("Can't allocate CUDA memory: {}", err);
-    });
-    this->callerInfo[0] = static_cast<U64>(numberOfPolarizations);
+    void** callerInfoPtr = nullptr;
+    void** callbackPointer = nullptr;
+
+    if (numberOfPolarizations == 1) {
+        callbackPointer = (void**)&d_1POL_loadCallbackPtr;
+    } else if (numberOfPolarizations == 2) {
+        callbackPointer = (void**)&d_2POL_loadCallbackPtr;
+    } else {
+        BL_CUDA_CHECK_THROW(cudaMallocManaged(&callerInfo, sizeof(U64)), [&]{
+            BL_FATAL("Can't allocate CUDA memory: {}", err);
+        });
+        this->callerInfo[0] = static_cast<U64>(numberOfPolarizations) * 2;
+
+        callerInfoPtr = (void**)&callerInfo;
+        callbackPointer = (void**)&d_loadCallbackPtr;
+    }
 
     BL_CUFFT_CHECK_THROW(cufftXtSetCallback(plan, 
-                                            (void**)&d_loadCallbackPtr, 
+                                            callbackPointer, 
                                             CUFFT_CB_LD_COMPLEX,
-                                            (void**)&callerInfo), [&]{
+                                            callerInfoPtr), [&]{
         BL_FATAL("The configuration of an cuFFT callback failed: {0:#x}", err);
     });
 

--- a/src/modules/channelizer/callback.cu
+++ b/src/modules/channelizer/callback.cu
@@ -1,0 +1,36 @@
+#include "blade/modules/channelizer/callback.hh"
+
+namespace Blade {
+namespace Internal {
+
+__device__ cufftComplex CB_ConvertInputC(void *dataIn, size_t offset, void *callerInfo, void *sharedPtr) {
+    return make_float2(0.0, 0.0);
+}
+
+__device__ cufftCallbackLoadC d_loadCallbackPtr = CB_ConvertInputC; 
+
+Callback::Callback(cufftHandle& plan) {
+    BL_CUDA_CHECK_THROW(cudaMemcpyFromSymbol(&h_loadCallbackPtr, 
+                                             d_loadCallbackPtr, 
+                                             sizeof(h_loadCallbackPtr)), [&]{
+        BL_FATAL("The allocation of an cuFFT callback failed: {}", err);
+    });
+
+    cufftResult status = cufftXtSetCallback(plan, 
+                                            (void**)&h_loadCallbackPtr, 
+                                            CUFFT_CB_LD_COMPLEX,
+                                            0);
+    if (status != CUFFT_SUCCESS) {
+        BL_FATAL("The configuration of an cuFFT callback failed: {0:#x}", status);
+        BL_CHECK_THROW(Result::CUDA_ERROR);
+    }
+
+    BL_CUDA_CHECK_KERNEL_THROW([&]{
+        BL_FATAL("Callbacks failed to install: {}", err);
+        return Result::CUDA_ERROR;
+    });
+
+ }
+
+}  // namespace Internal
+}  // namespace Blade

--- a/src/modules/channelizer/callback.cu
+++ b/src/modules/channelizer/callback.cu
@@ -23,14 +23,12 @@ Callback::Callback(cufftHandle& plan) {
         BL_FATAL("The allocation of an cuFFT callback failed: {}", err);
     });
 
-    cufftResult status = cufftXtSetCallback(plan, 
+    BL_CUFFT_CHECK_THROW(cufftXtSetCallback(plan, 
                                             (void**)&h_loadCallbackPtr, 
                                             CUFFT_CB_LD_COMPLEX,
-                                            0);
-    if (status != CUFFT_SUCCESS) {
-        BL_FATAL("The configuration of an cuFFT callback failed: {0:#x}", status);
-        BL_CHECK_THROW(Result::CUDA_ERROR);
-    }
+                                            0), [&]{
+        BL_FATAL("The configuration of an cuFFT callback failed: {0:#x}", err);
+    });
 
     BL_CUDA_CHECK_KERNEL_THROW([&]{
         BL_FATAL("Callbacks failed to install: {}", err);

--- a/src/modules/channelizer/callback.cu
+++ b/src/modules/channelizer/callback.cu
@@ -4,7 +4,14 @@ namespace Blade {
 namespace Internal {
 
 __device__ cufftComplex CB_ConvertInputC(void *dataIn, size_t offset, void *callerInfo, void *sharedPtr) {
-    return make_float2(0.0, 0.0);
+    auto& element = static_cast<cufftComplex*>(dataIn)[offset];
+
+    if ((offset % 2) != 0){
+        element.x = -element.x;
+        element.y = -element.y;
+    }
+
+    return element;
 }
 
 __device__ cufftCallbackLoadC d_loadCallbackPtr = CB_ConvertInputC; 
@@ -29,8 +36,7 @@ Callback::Callback(cufftHandle& plan) {
         BL_FATAL("Callbacks failed to install: {}", err);
         return Result::CUDA_ERROR;
     });
-
- }
+}
 
 }  // namespace Internal
 }  // namespace Blade

--- a/src/modules/channelizer/meson.build
+++ b/src/modules/channelizer/meson.build
@@ -9,6 +9,7 @@ endforeach
 if all_deps_found
     src_lst += files([
         'base.cc',
+        'callback.cu',
     ])
 
     jit_lst += files([

--- a/src/modules/detector/base.cc
+++ b/src/modules/detector/base.cc
@@ -7,7 +7,9 @@
 namespace Blade::Modules {
 
 template<typename IT, typename OT>
-Detector<IT, OT>::Detector(const Config& config, const Input& input)
+Detector<IT, OT>::Detector(const Config& config,
+                           const Input& input,
+                           const cudaStream_t& stream)
         : Module(detector_program),
           config(config),
           input(input),

--- a/src/modules/guppi/reader.cc
+++ b/src/modules/guppi/reader.cc
@@ -48,7 +48,9 @@ inline guppiraw_block_meta_t* getBlockMeta(const guppiraw_iterate_info_t* gr_ite
 }
 
 template<typename OT>
-Reader<OT>::Reader(const Config& config, const Input& input)
+Reader<OT>::Reader(const Config& config,
+                   const Input& input,
+                   const cudaStream_t& stream)
         : Module(guppi_program),
           config(config),
           input(input) {

--- a/src/modules/guppi/writer.cc
+++ b/src/modules/guppi/writer.cc
@@ -7,7 +7,9 @@
 namespace Blade::Modules::Guppi {
 
 template<typename IT>
-Writer<IT>::Writer(const Config& config, const Input& input)
+Writer<IT>::Writer(const Config& config, 
+                   const Input& input,
+                   const cudaStream_t& stream)
         : Module(guppi_program),
           config(config),
           input(input),

--- a/src/modules/phasor/ata.cc
+++ b/src/modules/phasor/ata.cc
@@ -52,8 +52,9 @@ namespace Blade::Modules::Phasor {
 
 template<typename OT>
 ATA<OT>::ATA(const typename Generic<OT>::Config& config,
-             const typename Generic<OT>::Input& input)
-        : Generic<OT>(config, input) {
+             const typename Generic<OT>::Input& input,
+             const cudaStream_t& stream)
+        : Generic<OT>(config, input, stream) {
     // Check configuration values.
     const auto& dataNumberOfChannels = this->config.numberOfFrequencyChannels;
     const auto& calibrationNumberOfChannels = config.antennaCalibrations.dims().numberOfFrequencyChannels();

--- a/src/modules/phasor/generic.cc
+++ b/src/modules/phasor/generic.cc
@@ -9,7 +9,9 @@
 namespace Blade::Modules::Phasor {
 
 template<typename OT>
-Generic<OT>::Generic(const Config& config, const Input& input)
+Generic<OT>::Generic(const Config& config, 
+                     const Input& input,
+                     const cudaStream_t& stream)
         : Module(phasor_program),
           config(config),
           input(input),

--- a/src/modules/polarizer/base.cc
+++ b/src/modules/polarizer/base.cc
@@ -40,7 +40,7 @@ Polarizer<IT, OT>::Polarizer(const Config& config,
         BL_FATAL("This module requires the type of the input "
                  "({}) and output ({}) to be the same.",
                  TypeInfo<IT>::name, TypeInfo<OT>::name); 
-        BL_INFO("Contact the maintainer if this"
+        BL_INFO("Contact the maintainer if this "
                 "functionality is required.");
         BL_CHECK_THROW(Result::ERROR);
     }

--- a/src/modules/polarizer/base.cc
+++ b/src/modules/polarizer/base.cc
@@ -10,7 +10,9 @@
 namespace Blade::Modules {
 
 template<typename IT, typename OT>
-Polarizer<IT, OT>::Polarizer(const Config& config, const Input& input)
+Polarizer<IT, OT>::Polarizer(const Config& config, 
+                             const Input& input, 
+                             const cudaStream_t& stream)
         : Module(polarizer_program),
           config(config),
           input(input) {

--- a/src/modules/polarizer/base.cc
+++ b/src/modules/polarizer/base.cc
@@ -34,13 +34,20 @@ Polarizer<IT, OT>::Polarizer(const Config& config, const Input& input)
         )
     );
 
-    // Allocate output buffers.
+    if constexpr (!std::is_same<IT, OT>::value) {
+        BL_FATAL("This module requires the type of the input "
+                 "({}) and output ({}) to be the same.",
+                 TypeInfo<IT>::name, TypeInfo<OT>::name); 
+        BL_INFO("Contact the maintainer if this"
+                "functionality is required.");
+        BL_CHECK_THROW(Result::ERROR);
+    }
+
+    // Link output buffers.
     if (config.mode == Mode::BYPASS) {
         BL_INFO("Bypass: Enabled");
-        BL_CHECK_THROW(output.buf.link(input.buf));
-    } else {
-        BL_CHECK_THROW(output.buf.resize(getOutputBufferDims()));
     }
+    BL_CHECK_THROW(output.buf.link(input.buf));
 
     // Print configuration values.
     BL_INFO("Type: {} -> {}", TypeInfo<IT>::name, TypeInfo<OT>::name);

--- a/src/modules/polarizer/polarizer.cu
+++ b/src/modules/polarizer/polarizer.cu
@@ -7,17 +7,16 @@ __global__ void polarizer(const IT* input, OT* output) {
     const int tid = (blockIdx.x * blockDim.x + threadIdx.x) * 2;
 
     if (tid < (N * 2)) {
-        const IT& xPol = input[tid + 0];
-        const OT& yPol = input[tid + 1];
-
         // The complex multiplication below can be simplified because
         // the real part of the phasor is 0.0. Boring implementation:
         // const IT yPol90 = cuCmulf(yPol, makeuFloatComplex(0.0, 1.0));
 
+        const OT& yPol = input[tid + 1];
         const float x = -cuCimagf(yPol);
         const float y = +cuCrealf(yPol);
         const IT yPol90 = make_cuFloatComplex(x, y);
 
+        const IT xPol = input[tid + 0];
         output[tid + 0] = cuCaddf(xPol, yPol90);
         output[tid + 1] = cuCsubf(xPol, yPol90);
     }

--- a/tests/modules/channelizer/meson.build
+++ b/tests/modules/channelizer/meson.build
@@ -1,7 +1,7 @@
 if cfg_lst.get('BLADE_MODULE_CHANNELIZER', false)
     if has_python
         test(
-            'blade-channelize-hires-python',
+            'blade-channelize-hires-weird-python',
             find_program('python', 'python3'),
             args: [files('advanced.py'), '5', '100', '200', '1', '200'],
             is_parallel: false,
@@ -9,18 +9,36 @@ if cfg_lst.get('BLADE_MODULE_CHANNELIZER', false)
             env: 'PYTHONPATH=@0@'.format(python_path))
 
         test(
-            'blade-channelize-std-python',
+            'blade-channelize-hires-python',
             find_program('python', 'python3'),
-            args: [files('advanced.py'), '20', '96', '35000', '2', '4'],
+            args: [files('advanced.py'), '8', '128', '1024', '2', '1024'],
             is_parallel: false,
             timeout: 0,
             env: 'PYTHONPATH=@0@'.format(python_path))
 
         test(
-            'blade-channelize-std-beams-python',
+            'blade-channelize-hires-single-pol-python',
             find_program('python', 'python3'),
-            args: [files('advanced.py'), '20', '96', '35000', '2', '4'],
+            args: [files('advanced.py'), '8', '128', '1024', '1', '1024'],
             is_parallel: false,
+            timeout: 0,
+            env: 'PYTHONPATH=@0@'.format(python_path))
+
+        test(
+            'blade-channelize-fail-case-1-python',
+            find_program('python', 'python3'),
+            args: [files('advanced.py'), '8', '128', '1024', '1', '512'],
+            is_parallel: false,
+            should_fail: true,
+            timeout: 0,
+            env: 'PYTHONPATH=@0@'.format(python_path))
+
+        test(
+            'blade-channelize-fail-case-2-python',
+            find_program('python', 'python3'),
+            args: [files('advanced.py'), '8', '128', '1025', '1', '1025'],
+            is_parallel: false,
+            should_fail: true,
             timeout: 0,
             env: 'PYTHONPATH=@0@'.format(python_path))
     endif


### PR DESCRIPTION
Breaking changes in v0.8.0:
- The `include` path for the Channelizer module changed.
- The Channelizer modules do not support rates different than the number of time samples (big deal, pls read).

The Good:
1. Memory usage is way down because it's in-place. Toy Mode HB benchmark is using 900 MB per beam less VRAM.
2. The polarizer is also in-place and thus doesn't allocate memory.

The Bad:
1. Breaking changes (see above).
2. Not really faster with the current CUDA release (but should be in the near future).