### PR TITLE
++ modules/gather between RAM and VRAM

### DIFF
--- a/benchmarks/bundles/ata/mode-bh/mode_bh.hh
+++ b/benchmarks/bundles/ata/mode-bh/mode_bh.hh
@@ -129,7 +129,7 @@ class Benchmark : public Runner {
  private:
     std::shared_ptr<ModeB> modeB;
     std::shared_ptr<ModeH> modeH;
-    std::shared_ptr<Modules::Gather<CF32, CF32>> gather;
+    std::shared_ptr<Modules::Gather<Device::CUDA, CF32, Device::CUDA, CF32>> gather;
 
     Duet<Tensor<Device::CPU, F64>> inputDut;
     Duet<Tensor<Device::CPU, F64>> inputJulianDate;

--- a/benchmarks/modules/gather/base.hh
+++ b/benchmarks/modules/gather/base.hh
@@ -7,12 +7,12 @@
 
 namespace Blade {
 
-template<template<typename, typename> class MUT, typename IT, typename OT>
+template<template<Device, typename, Device, typename> class MUT, Device ID, typename IT, Device OD, typename OT>
 class GatherTest : CudaBenchmark {
  public:
-    typename MUT<IT, OT>::Config config;
-    std::shared_ptr<MUT<IT, OT>> module;
-    ArrayTensor<Device::CUDA, IT> deviceInputBuf;
+    typename MUT<ID, IT, OD, OT>::Config config;
+    std::shared_ptr<MUT<ID, IT, OD, OT>> module;
+    ArrayTensor<ID, IT> deviceInputBuf;
 
     Result run(benchmark::State& state) {
         const U64 Axis = state.range(0);
@@ -25,7 +25,7 @@ class GatherTest : CudaBenchmark {
             config.multiplier = Mult;
             config.blockSize = 512;
 
-            deviceInputBuf = ArrayTensor<Device::CUDA, IT>({5, F, T, 2});
+            deviceInputBuf = ArrayTensor<ID, IT>({5, F, T, 2});
 
             BL_DISABLE_PRINT();
             Create(module, config, {

--- a/benchmarks/modules/gather/generic.hh
+++ b/benchmarks/modules/gather/generic.hh
@@ -6,7 +6,7 @@ namespace bm = benchmark;
 // CF32 -> CF32
 
 static void BM_Gather_Compute_CF32_CF32(bm::State& state) {
-    GatherTest<Modules::Gather, CF32, CF32> mud;
+    GatherTest<Modules::Gather, Device::CUDA, CF32, Device::CUDA, CF32> mud;
     BL_CHECK_THROW(mud.run(state));
 }
 
@@ -20,7 +20,7 @@ BENCHMARK(BM_Gather_Compute_CF32_CF32)
 // F16 -> F16
 
 static void BM_Gather_Compute_F16_F16(bm::State& state) {
-    GatherTest<Modules::Gather, CF16, CF16> mud;
+    GatherTest<Modules::Gather, Device::CUDA, CF16, Device::CUDA, CF16> mud;
     BL_CHECK_THROW(mud.run(state));
 }
 

--- a/examples/pipeline-cpp/pipeline.cc
+++ b/examples/pipeline-cpp/pipeline.cc
@@ -43,7 +43,7 @@ class ExamplePipeline : public Runner {
 
  private:
     std::shared_ptr<Modules::Cast<IT, F32>> inputCast;
-    std::shared_ptr<Modules::Gather<F32, F32>> gather;
+    std::shared_ptr<Modules::Gather<Device::CUDA, F32, Device::CUDA, F32>> gather;
     std::shared_ptr<Modules::Cast<F32, OT>> outputCast;
 
     Duet<ArrayTensor<Device::CUDA, IT>> inputBuffer;

--- a/include/blade/modules/gather.hh
+++ b/include/blade/modules/gather.hh
@@ -9,7 +9,7 @@ namespace Blade::Modules {
 // TODO: Add support for input with fixed axis larger than one.
 // MAYDO: Add built-in casting, if necessary.
 // MAYDO: Add support for types different than ArrayTensor, if necessary.
-template<typename IT, typename OT>
+template<Device ID, typename IT, Device OD, typename OT>
 class BLADE_API Gather : public Module {
  public:
     // Configuration
@@ -29,20 +29,20 @@ class BLADE_API Gather : public Module {
     // Input
 
     struct Input {
-        const ArrayTensor<Device::CUDA, IT>& buf;
+        const ArrayTensor<ID, IT>& buf;
     };
 
-    constexpr const ArrayTensor<Device::CUDA, IT>& getInputBuffer() const {
+    constexpr const ArrayTensor<ID, IT>& getInputBuffer() const {
         return this->input.buf;
     }
 
     // Output 
 
     struct Output {
-        ArrayTensor<Device::CUDA, OT> buf;
+        ArrayTensor<OD, OT> buf;
     };
 
-    constexpr const ArrayTensor<Device::CUDA, OT>& getOutputBuffer() const {
+    constexpr const ArrayTensor<OD, OT>& getOutputBuffer() const {
         return this->output.buf;
     }
 

--- a/python/blade/ext_gather.cc
+++ b/python/blade/ext_gather.cc
@@ -8,12 +8,12 @@ namespace nb = nanobind;
 using namespace nb::literals;
 using namespace Blade;
 
-template<typename IT, typename OT>
-void NB_SUBMODULE(auto& m, const auto& in_name, const auto& out_name) {
-    using Class = Modules::Gather<IT, OT>;
+template<Device ID, typename IT, Device OD, typename OT>
+void NB_SUBMODULE_TYPE_DIRECTION(auto& m, const auto& in_datatype_name, const auto& out_datatype_name, const auto& in_dev_name, const auto& out_dev_name) {
+    using Class = Modules::Gather<ID, IT, OD, OT>;
 
-    auto mm = m.def_submodule(in_name)
-               .def_submodule(out_name);
+    auto mm = m.def_submodule(in_datatype_name)
+               .def_submodule(out_datatype_name);
 
     nb::class_<Class, Module> mod(mm, "mod");
 
@@ -27,7 +27,7 @@ void NB_SUBMODULE(auto& m, const auto& in_name, const auto& out_name) {
                                      "block_size"_a = 512);
 
     nb::class_<typename Class::Input>(mod, "input")
-        .def(nb::init<const ArrayTensor<Device::CUDA, IT>&>(), "buffer"_a);
+        .def(nb::init<const ArrayTensor<ID, IT>&>(), "buffer"_a);
 
     mod
         .def(nb::init<const typename Class::Config&,
@@ -46,9 +46,21 @@ void NB_SUBMODULE(auto& m, const auto& in_name, const auto& out_name) {
         });
 }
 
+
+template<typename DataType>
+void NB_SUBMODULE_GATHER_TYPE(auto& m, const auto& in_datatype_name, const auto& out_datatype_name) {
+    NB_SUBMODULE_TYPE_DIRECTION<Device::CUDA, DataType, Device::CUDA, DataType>(m, in_datatype_name, out_datatype_name, "src_cuda", "dest_cuda");
+    NB_SUBMODULE_TYPE_DIRECTION<Device::CUDA, DataType, Device::CPU, DataType>(m, in_datatype_name, out_datatype_name, "src_cuda", "dest_cpu");
+    NB_SUBMODULE_TYPE_DIRECTION<Device::CPU, DataType, Device::CUDA, DataType>(m, in_datatype_name, out_datatype_name, "src_cpu", "dest_cuda");
+}
+
+void NB_SUBMODULE_GATHER(auto& m) {
+    NB_SUBMODULE_GATHER_TYPE<F32>(m, "in_f64", "out_f64");
+    NB_SUBMODULE_GATHER_TYPE<CF32>(m, "in_cf32", "out_cf32");
+    NB_SUBMODULE_GATHER_TYPE<CF16>(m, "in_cf16", "out_cf16");
+    NB_SUBMODULE_GATHER_TYPE<CI8>(m, "in_ci8", "out_ci8");
+}
+
 NB_MODULE(_gather_impl, m) {
-    NB_SUBMODULE<F32, F32>(m, "in_f64", "out_f64");
-    NB_SUBMODULE<CF32, CF32>(m, "in_cf32", "out_cf32");
-    NB_SUBMODULE<CF16, CF16>(m, "in_cf16", "out_cf16");
-    NB_SUBMODULE<CI8, CI8>(m, "in_ci8", "out_ci8");
+    NB_SUBMODULE_GATHER(m);
 }


### PR DESCRIPTION
I need to gather large amounts of data and so need to do so in RAM. The gather module's Copy2D can simultaneously transfer to RAM while gathering... not supported is CPU->CPU gathering, so CUDA is always involved. For this necessary evil that's as good as it will get.

I'm just struggling to wrap up the python portion of this... I've extended the test.


Alternative would be to make a Transfer module that enables this transfer as a flat copy between devices in a pipeline.. maybe it'd be as fast/faster, but is doesn't seem as neat, and I bet I'd have the same issues with the python wrap seeing as it also needs to differentiate between CPU->CUDA and CUDA->CPU...

I can't go further without this... ~~If you're tied up, I'll make a temporary TransferToHost module that statically copies from VRAM to RAM.~~