### PR TITLE
Add internal double precision arithmetic inside Correlator kernel.

### DIFF
--- a/include/blade/memory/device/ops.hh
+++ b/include/blade/memory/device/ops.hh
@@ -2,6 +2,7 @@
 #define BLADE_MEMORY_DEVICE_OPS_HH
 
 #include <cstdint>
+#include <type_traits>
 
 #include <cuda_fp16.h>
 
@@ -24,13 +25,9 @@ class alignas(2 * sizeof(T)) complex {
     __host__ __device__ complex(T r) : _real(r), _imag(0) {}
     __host__ __device__ complex(T r, T i) : _real(r), _imag(i) {}
 
-    // CF32 -> CF64
-    __host__ __device__ explicit complex(const complex<float>& rhs) : _real(static_cast<T>(rhs.real())), _imag(static_cast<T>(rhs.imag())) {}
-
-    // CF64 -> CF32
-    __host__ __device__ operator complex<float>() const {
-        return complex<float>(static_cast<float>(_real), static_cast<float>(_imag));
-    }
+    template <typename U, typename = std::enable_if_t<std::is_same<U, float>::value || std::is_same<U, double>::value>>
+    __host__ __device__ explicit complex(const complex<U>& rhs) : _real(static_cast<T>(rhs.real())), _imag(static_cast<T>(rhs.imag())) {}
+    // TODO: Add support for half to float/double conversion.
 
     __host__ __device__ complex<T> operator+(const complex<T>& rhs) const {
         return complex<T>(_real + rhs._real, _imag + rhs._imag);

--- a/include/blade/memory/device/ops.hh
+++ b/include/blade/memory/device/ops.hh
@@ -24,6 +24,14 @@ class alignas(2 * sizeof(T)) complex {
     __host__ __device__ complex(T r) : _real(r), _imag(0) {}
     __host__ __device__ complex(T r, T i) : _real(r), _imag(i) {}
 
+    // CF32 -> CF64
+    __host__ __device__ explicit complex(const complex<float>& rhs) : _real(static_cast<T>(rhs.real())), _imag(static_cast<T>(rhs.imag())) {}
+
+    // CF64 -> CF32
+    __host__ __device__ operator complex<float>() const {
+        return complex<float>(static_cast<float>(_real), static_cast<float>(_imag));
+    }
+
     __host__ __device__ complex<T> operator+(const complex<T>& rhs) const {
         return complex<T>(_real + rhs._real, _imag + rhs._imag);
     }

--- a/src/modules/correlator/base.cc
+++ b/src/modules/correlator/base.cc
@@ -29,8 +29,8 @@ Correlator<IT, OT>::Correlator(const Config& config,
         BL_CHECK_THROW(Result::ERROR);
     }
 
-    if (getInputBuffer().shape().numberOfTimeSamples() <= 0) {
-        BL_FATAL("Number of time samples ({}) should be more than zero.",
+    if (getInputBuffer().shape().numberOfTimeSamples() != 1) {
+        BL_FATAL("Number of time samples ({}) should be exactly one.",
                  getInputBuffer().shape().numberOfTimeSamples());
         BL_CHECK_THROW(Result::ERROR);
     }
@@ -55,23 +55,8 @@ Correlator<IT, OT>::Correlator(const Config& config,
 
     // Choose best kernel based on input buffer size.
 
-    std::string kernel_key;
-    std::string pretty_kernel_key;
-
-    // Enable Shared Memory correlator if the size if less than 100 KB.
-    if (((getInputBuffer().size() / getInputBuffer().shape().numberOfAspects()) * sizeof(IT)) < 100000) {
-        kernel_key = "correlator_sm";
-        pretty_kernel_key = "Shared Memory";
-    } else {
-        kernel_key = "correlator";
-        pretty_kernel_key = "Global Memory";
-    }
-
-    // Enable Integration kernel if integration size is more than one.
-    if (getInputBuffer().shape().numberOfTimeSamples() > 1) {
-        kernel_key = "correlator_integrator";
-        pretty_kernel_key = "Global Memory Time Integrator";
-    }
+    std::string kernel_key = "correlator";
+    std::string pretty_kernel_key = "Global Memory";
 
     if (kernel_key.empty()) {
         BL_FATAL("Can't find any compatible kernel.");

--- a/src/modules/correlator/correlator.cu
+++ b/src/modules/correlator/correlator.cu
@@ -13,85 +13,6 @@ using namespace Blade;
 // Blocks per Grid:   [20, 4]
 // Threads Per Block: [50]
 
-// 
-// Fast but limited by the shared memory size.
-//
-
-template<typename IT, typename OT, U64 A, U64 C, U64 T, U64 P, U64 BLOCK_SIZE>
-__global__ void correlator_sm(const ArrayTensor<Device::CUDA, IT> input, 
-                                    ArrayTensor<Device::CUDA, OT> output) {
-    // 1. Load antenna data chunk into shared memory.
-    // 2. Do the multiply conjugate (XX = AX * CONJ(BX)).
-    // 3. Store the result in the output tensor.
-
-    // Get Block index.
-    
-    const U64 BIX = blockIdx.x;  // Block Index X
-    const U64 BIY = blockIdx.y;  // Block Index Y
-
-    // Get Thread index.
-
-    const U64 TIX = threadIdx.x;  // Thread Index X
-
-    // Calculate constants.
-
-    const U64 OUTPUT_POLS = 4;                // XX, XY, YX, YY
-    const U64 AAI = BIX;                      // Antenna A Index
-    const U64 CI = TIX + (BIY * BLOCK_SIZE);  // Channel Index 
-
-    // Declare shared memory within block.
-
-    __shared__ IT reference_antenna_data[C][T][P];
-
-    // Load block of input data into shared memory.
-
-    for (U64 TI = 0; TI < T; TI++) {
-        for (U64 PI = 0; PI < P; PI++) {
-            const U64 ANTENNA_A_INDEX = (AAI * C * T * P) + (CI * T * P) + (TI * P) + PI;
-            reference_antenna_data[CI][TI][PI] = input[ANTENNA_A_INDEX];
-
-#ifdef DEBUG
-            printf("++ BIX: %ld/%d, BIY: %ld/%d, TIX: %ld || AAI: %ld, CI: %ld, TI: %ld, PI: %ld || ANTENNA_A_INDEX: %ld\n", 
-                   BIX, gridDim.x, BIY, gridDim.y, TIX, AAI, CI, TI, PI, ANTENNA_A_INDEX);
-#endif
-        }
-    }
-    __syncthreads();
-
-    // Run the correlation and store the result in the output tensor.
-
-    for (U64 ABI = AAI; ABI < A; ABI++) {
-        const U64 BASELINE_INDEX = ((AAI * (2 * A - AAI + 1)) / 2) + (ABI - AAI);
-
-        for (U64 TI = 0; TI < T; TI++) {
-            const U64 ANTENNA_B_INDEX = (ABI * C * T * P) + (CI * T * P) + (TI * P);
-
-            const IT& AVAX = reference_antenna_data[CI][TI][0];  // Antenna Voltage A Pol X
-            const IT& AVAY = reference_antenna_data[CI][TI][1];  // Antenna Voltage A Pol Y
-
-            const IT& AVBX = input[ANTENNA_B_INDEX + 0];  // Antenna Voltage B Pol X
-            const IT& AVBY = input[ANTENNA_B_INDEX + 1];  // Antenna Voltage B Pol Y
-
-            const OT XX = AVAX * AVBX.conj();  // XX
-            const OT XY = AVAX * AVBY.conj();  // XY
-            const OT YX = AVAY * AVBX.conj();  // YX
-            const OT YY = AVAY * AVBY.conj();  // YY
-
-            const U64 OUTPUT_INDEX = (BASELINE_INDEX * C * T * OUTPUT_POLS) + (CI * T * OUTPUT_POLS) + (TI * OUTPUT_POLS);
-
-            output[OUTPUT_INDEX + 0] += XX;
-            output[OUTPUT_INDEX + 1] += XY;
-            output[OUTPUT_INDEX + 2] += YX;
-            output[OUTPUT_INDEX + 3] += YY;
-                
-#ifdef DEBUG
-            printf("-- BIX: %ld/%d, BIY: %ld/%d, TIX: %ld || ABI: %ld, CI: %ld, TI: %ld || BASELINE_INDEX: %ld, OUTPUT_INDEX: %ld\n",
-                    BIX, gridDim.x, BIY, gridDim.y, TIX, ABI, CI, TI, BASELINE_INDEX, OUTPUT_INDEX);
-#endif
-        }
-    }
-}
-
 //
 // Global memory version without shared memory.
 //
@@ -134,90 +55,22 @@ __global__ void correlator(const ArrayTensor<Device::CUDA, IT> input,
             const auto AVBX = static_cast<CF64>(input[ANTENNA_B_INDEX + 0]);  // Antenna Voltage B Pol X
             const auto AVBY = static_cast<CF64>(input[ANTENNA_B_INDEX + 1]);  // Antenna Voltage B Pol Y
 
-            const OT XX = AVAX * AVBX.conj();  // XX
-            const OT XY = AVAX * AVBY.conj();  // XY
-            const OT YX = AVAY * AVBX.conj();  // YX
-            const OT YY = AVAY * AVBY.conj();  // YY
+            const auto XX = AVAX * AVBX.conj();  // XX
+            const auto XY = AVAX * AVBY.conj();  // XY
+            const auto YX = AVAY * AVBX.conj();  // YX
+            const auto YY = AVAY * AVBY.conj();  // YY
 
             const U64 OUTPUT_INDEX = (BASELINE_INDEX * C * T * OUTPUT_POLS) + (CI * T * OUTPUT_POLS) + (TI * OUTPUT_POLS);
 
-            output[OUTPUT_INDEX + 0] += XX;
-            output[OUTPUT_INDEX + 1] += XY;
-            output[OUTPUT_INDEX + 2] += YX;
-            output[OUTPUT_INDEX + 3] += YY;
+            output[OUTPUT_INDEX + 0] += static_cast<OT>(XX);
+            output[OUTPUT_INDEX + 1] += static_cast<OT>(XY);
+            output[OUTPUT_INDEX + 2] += static_cast<OT>(YX);
+            output[OUTPUT_INDEX + 3] += static_cast<OT>(YY);
                 
 #ifdef DEBUG
             printf("-- BIX: %ld/%d, BIY: %ld/%d, TIX: %ld || ABI: %ld, CI: %ld, TI: %ld || AAI: %ld, ABI: %ld || BASELINE_INDEX: %ld, OUTPUT_INDEX: %ld\n",
                    BIX, gridDim.x, BIY, gridDim.y, TIX, ABI, CI, TI, ANTENNA_A_INDEX, ANTENNA_B_INDEX, BASELINE_INDEX, OUTPUT_INDEX);
 #endif
         }
-    }
-}
-
-//
-// Global memory version with integration.
-//
-
-template<typename IT, typename OT, U64 A, U64 C, U64 T, U64 P, U64 BLOCK_SIZE>
-__global__ void correlator_integrator(const ArrayTensor<Device::CUDA, IT> input, 
-                                            ArrayTensor<Device::CUDA, OT> output) {
-    // 1. Load antenna A and B data.
-    // 2. Create temporary variables to accumulate the result.
-    // 3. Add the multiply conjugate (XX = AX * CONJ(BX)) result to the temporary variables.
-    // 4. Store the result in the output tensor.
-
-    // Get Block index.
-    
-    const U64 BIX = blockIdx.x;  // Block Index X
-    const U64 BIY = blockIdx.y;  // Block Index Y
-
-    // Get Thread index.
-
-    const U64 TIX = threadIdx.x;  // Thread Index X
-
-    // Calculate constants.
-
-    const U64 OUTPUT_POLS = 4;                // XX, XY, YX, YY
-    const U64 AAI = BIX;                      // Antenna A Index
-    const U64 CI = TIX + (BIY * BLOCK_SIZE);  // Channel Index
-
-    // Run the correlation and store the result in the output tensor.
-
-    for (U64 ABI = AAI; ABI < A; ABI++) {
-        const U64 BASELINE_INDEX = ((AAI * (2 * A - AAI + 1)) / 2) + (ABI - AAI);
-        
-        OT sumXX = OT(0.0f, 0.0f);
-        OT sumXY = OT(0.0f, 0.0f);
-        OT sumYX = OT(0.0f, 0.0f);
-        OT sumYY = OT(0.0f, 0.0f);
-
-        for (U64 TI = 0; TI < T; TI++) {
-            const U64 ANTENNA_A_INDEX = (AAI * C * T * P) + (CI * T * P) + (TI * P);
-
-            const IT& AVAX = input[ANTENNA_A_INDEX + 0];  // Antenna Voltage A Pol X
-            const IT& AVAY = input[ANTENNA_A_INDEX + 1];  // Antenna Voltage A Pol Y
-
-            const U64 ANTENNA_B_INDEX = (ABI * C * T * P) + (CI * T * P) + (TI * P);
-
-            const IT& AVBX = input[ANTENNA_B_INDEX + 0];  // Antenna Voltage B Pol X
-            const IT& AVBY = input[ANTENNA_B_INDEX + 1];  // Antenna Voltage B Pol Y
-
-            sumXX += AVAX * AVBX.conj();  // XX
-            sumXY += AVAX * AVBY.conj();  // XY
-            sumYX += AVAY * AVBX.conj();  // YX
-            sumYY += AVAY * AVBY.conj();  // YY
-        }
-
-        const U64 OUTPUT_INDEX = (BASELINE_INDEX * C * OUTPUT_POLS) + (CI * OUTPUT_POLS);
-
-        output[OUTPUT_INDEX + 0] += sumXX;
-        output[OUTPUT_INDEX + 1] += sumXY;
-        output[OUTPUT_INDEX + 2] += sumYX;
-        output[OUTPUT_INDEX + 3] += sumYY;
-
-#ifdef DEBUG
-        printf("-- BIX: %ld/%d, BIY: %ld/%d, TIX: %ld || ABI: %ld, CI: %ld || AAI: %ld, ABI: %ld || BASELINE_INDEX: %ld, OUTPUT_INDEX: %ld\n",
-               BIX, gridDim.x, BIY, gridDim.y, TIX, ABI, CI, AAI, ABI, BASELINE_INDEX, OUTPUT_INDEX);
-#endif
     }
 }

--- a/src/modules/correlator/correlator.cu
+++ b/src/modules/correlator/correlator.cu
@@ -126,13 +126,13 @@ __global__ void correlator(const ArrayTensor<Device::CUDA, IT> input,
         for (U64 TI = 0; TI < T; TI++) {
             const U64 ANTENNA_A_INDEX = (AAI * C * T * P) + (CI * T * P) + (TI * P);
 
-            const IT& AVAX = input[ANTENNA_A_INDEX + 0];  // Antenna Voltage A Pol X
-            const IT& AVAY = input[ANTENNA_A_INDEX + 1];  // Antenna Voltage A Pol Y
+            const auto AVAX = static_cast<CF64>(input[ANTENNA_A_INDEX + 0]);  // Antenna Voltage A Pol X
+            const auto AVAY = static_cast<CF64>(input[ANTENNA_A_INDEX + 1]);  // Antenna Voltage A Pol Y
 
             const U64 ANTENNA_B_INDEX = (ABI * C * T * P) + (CI * T * P) + (TI * P);
 
-            const IT& AVBX = input[ANTENNA_B_INDEX + 0];  // Antenna Voltage B Pol X
-            const IT& AVBY = input[ANTENNA_B_INDEX + 1];  // Antenna Voltage B Pol Y
+            const auto AVBX = static_cast<CF64>(input[ANTENNA_B_INDEX + 0]);  // Antenna Voltage B Pol X
+            const auto AVBY = static_cast<CF64>(input[ANTENNA_B_INDEX + 1]);  // Antenna Voltage B Pol Y
 
             const OT XX = AVAX * AVBX.conj();  // XX
             const OT XY = AVAX * AVBY.conj();  // XY


### PR DESCRIPTION
The Correlator module will perform double precision multiply conjugate internally even if the input and output types are single precision. This is done to get the benefits of double precision arithmetic without the burden of increased memory usage and load/store times.

- The Correlator module will perform the multiply conjugate operation in double-precision mode.
- The single-precision float inputs will be cast to double-precision just in time, before the computation.
- This maintains the same memory usage as using single-precision throughout, by avoiding the need to store double-precision values.

**Benefits:**
- Improved numerical precision and stability for the Correlator module.
- No increase in memory usage or load/store times compared to single-precision implementation.
- Transparent to users - the input/output types can remain single-precision.

**Potential Drawbacks:**
- Slightly increased computational cost due to the internal double-precision arithmetic.

Overall, this change provides a good balance between numerical quality and performance and should be transparent to users of the Correlator module.