### PR TITLE
*+ runner.enqueue(..., transferCallback, ...)

### DIFF
--- a/benchmarks/bundles/ata/mode-b/mode_b.hh
+++ b/benchmarks/bundles/ata/mode-b/mode_b.hh
@@ -138,6 +138,9 @@ class BenchmarkRunner {
                 const U64 i = enqueueCount++ % 2;
                 return pipeline->transferIn(inputDut1[i], inputJulianDate[i], inputBuffer[i]);
             };
+            auto transferCallback = [&](){
+                return Result::SUCCESS;
+            };
             auto resultCallback = [&](){
                 return pipeline->transferResult();
             };
@@ -145,7 +148,7 @@ class BenchmarkRunner {
                 const U64 i = dequeueCount++ % 2;
                 return pipeline->transferOut(outputBuffer[i]);
             };
-            BL_CHECK(pipeline->enqueue(inputCallback, resultCallback, outputCallback, enqueueCount, dequeueCount));
+            BL_CHECK(pipeline->enqueue(inputCallback, transferCallback, resultCallback, outputCallback, enqueueCount, dequeueCount));
 
             BL_CHECK(pipeline->dequeue([&](const U64& inputId,
                                            const U64& outputId,

--- a/benchmarks/bundles/ata/mode-bh/mode_bh.hh
+++ b/benchmarks/bundles/ata/mode-bh/mode_bh.hh
@@ -220,6 +220,9 @@ class BenchmarkRunner {
                 const U64 i = enqueueCount++ % 2;
                 return pipeline->transferIn(inputDut1[i], inputJulianDate[i], inputBuffer[i]);
             };
+            auto transferCallback = [&](){
+                return Result::SUCCESS;
+            };
             auto resultCallback = [&](){
                 return pipeline->transferResult();
             };
@@ -227,7 +230,7 @@ class BenchmarkRunner {
                 const U64 i = dequeueCount++ % 2;
                 return pipeline->transferOut(outputBuffer[i]);
             };
-            BL_CHECK(pipeline->enqueue(inputCallback, resultCallback, outputCallback, enqueueCount, dequeueCount));
+            BL_CHECK(pipeline->enqueue(inputCallback, transferCallback, resultCallback, outputCallback, enqueueCount, dequeueCount));
 
             BL_CHECK(pipeline->dequeue([&](const U64& inputId,
                                            const U64& outputId,

--- a/benchmarks/bundles/benchmark.cc
+++ b/benchmarks/bundles/benchmark.cc
@@ -2,6 +2,7 @@
 
 #include "blade/types.hh"
 
+/*
 #if defined(BLADE_BUNDLE_ATA_MODE_B)
 #include "./ata/mode-b/generic.hh"
 #endif
@@ -14,6 +15,7 @@
 #if defined(BLADE_BUNDLE_GENERIC_MODE_H)
 #include "./generic/mode-h/generic.hh"
 #endif
+*/
 
 #if defined(BLADE_BUNDLE_GENERIC_MODE_X)
 #include "./generic/mode-x/generic.hh"

--- a/benchmarks/bundles/generic/mode-h/mode_h.hh
+++ b/benchmarks/bundles/generic/mode-h/mode_h.hh
@@ -75,6 +75,9 @@ class BenchmarkRunner {
                 const U64 i = enqueueCount++ % 2;
                 return pipeline->transferIn(inputBuffer[i]);
             };
+            auto transferCallback = [&](){
+                return Result::SUCCESS;
+            };
             auto resultCallback = [&](){
                 return pipeline->transferResult();
             };
@@ -82,7 +85,7 @@ class BenchmarkRunner {
                 const U64 i = dequeueCount++ % 2;
                 return pipeline->transferOut(outputBuffer[i]);
             };
-            BL_CHECK(pipeline->enqueue(inputCallback, resultCallback, outputCallback, enqueueCount, dequeueCount));
+            BL_CHECK(pipeline->enqueue(inputCallback, transferCallback, resultCallback, outputCallback, enqueueCount, dequeueCount));
 
             BL_CHECK(pipeline->dequeue([&](const U64& inputId,
                                            const U64& outputId,

--- a/benchmarks/bundles/generic/mode-x/mode_x.hh
+++ b/benchmarks/bundles/generic/mode-x/mode_x.hh
@@ -79,6 +79,9 @@ class BenchmarkRunner {
                 const U64 i = enqueueCount++ % 2;
                 return pipeline->transferIn(inputBuffer[i]);
             };
+            auto transferCallback = [&](){
+                return Result::SUCCESS;
+            };
             auto resultCallback = [&](){
                 return pipeline->transferResult();
             };
@@ -86,7 +89,7 @@ class BenchmarkRunner {
                 const U64 i = dequeueCount++ % 2;
                 return pipeline->transferOut(outputBuffer[i]);
             };
-            BL_CHECK(pipeline->enqueue(inputCallback, resultCallback, outputCallback, enqueueCount, dequeueCount));
+            BL_CHECK(pipeline->enqueue(inputCallback, transferCallback, resultCallback, outputCallback, enqueueCount, dequeueCount));
 
             BL_CHECK(pipeline->dequeue([&](const U64& inputId,
                                            const U64& outputId,

--- a/examples/pipeline-cpp/pipeline.cc
+++ b/examples/pipeline-cpp/pipeline.cc
@@ -111,13 +111,16 @@ int main() {
         auto inputCallback = [&](){
             return pipeline->transferIn(inputBuffer[enqueueCount++ % 2]);
         };
+        auto transferCallback = [&](){
+            return Result::SUCCESS;
+        };
         auto resultCallback = [&](){
             return pipeline->transferResult();
         };
         auto outputCallback = [&](){
             return pipeline->transferOut(outputBuffer[dequeueCount++ % 2]);
         };
-        pipeline->enqueue(inputCallback, resultCallback, outputCallback, enqueueCount, dequeueCount);
+        pipeline->enqueue(inputCallback, transferCallback, resultCallback, outputCallback, enqueueCount, dequeueCount);
 
         pipeline->dequeue([&](const U64& inputId,
                               const U64& outputId,

--- a/include/blade/runner.hh
+++ b/include/blade/runner.hh
@@ -21,6 +21,7 @@ class BLADE_API Runner : public Pipeline {
                                  const bool& didOutput)> DequeueCallback;
 
     Result enqueue(const std::function<Result()>& inputCallback,
+                   const std::function<Result()>& transferCallback,
                    const std::function<Result()>& resultCallback,
                    const std::function<Result()>& outputCallback,
                    U64 inputId,

--- a/python/blade/ext_runner.cc
+++ b/python/blade/ext_runner.cc
@@ -64,7 +64,7 @@ NB_MODULE(_runner_impl, m) {
         nb::class_<Runner, Pipeline>(m, "runner")
             .def(nb::init<>())
             .def("enqueue", &Runner::enqueue,
-                 "inputCallback"_a, "resultCallback"_a, "outputCallback"_a, "inputId"_a, "outputId"_a)
+                 "inputCallback"_a, "transferCallback"_a, "resultCallback"_a, "outputCallback"_a, "inputId"_a, "outputId"_a)
             .def("dequeue", &Runner::dequeue,
                  "callback"_a)
             .def("__repr__", [](Runner& obj){


### PR DESCRIPTION
This PR aims to enable the caller to free/reuse host-memory after the HtoD transfer is done...

How:
- Assuming the [wait()](https://github.com/luigifcruz/blade/blob/v1.1/src/runner.cc#L34) synchronises the subsequent LoC on the input transfer...
- just execute an additional callback after the transfer and before the `compute()` call.