### PR TITLE
Manually Trigger CUDA Kernel Compilation

### DIFF
--- a/benchmarks/bundles/generic/mode-h/mode_h.hh
+++ b/benchmarks/bundles/generic/mode-h/mode_h.hh
@@ -63,6 +63,7 @@ class BenchmarkRunner {
             inputBuffer.push_back(ArrayTensor<Device::CPU, IT>(config.inputShape));
             outputBuffer.push_back(ArrayTensor<Device::CPU, OT>(config.outputShape));
         }
+        pipeline->compile();
     }
 
     Result run(const U64& totalIterations) {

--- a/benchmarks/bundles/generic/mode-x/mode_x.hh
+++ b/benchmarks/bundles/generic/mode-x/mode_x.hh
@@ -67,6 +67,7 @@ class BenchmarkRunner {
             inputBuffer.push_back(ArrayTensor<Device::CPU, IT>(config.inputShape));
             outputBuffer.push_back(ArrayTensor<Device::CPU, OT>(config.outputShape));
         }
+        pipeline->compile(0);
     }
 
     Result run(const U64& totalIterations) {

--- a/include/blade/module.hh
+++ b/include/blade/module.hh
@@ -36,6 +36,10 @@ class Module {
         return Result::SUCCESS;
     }
 
+    virtual Result compile(const Stream& stream = {}) {
+        return this->compileKernel("main", stream);
+    }
+
  protected:
     jitify2::ProgramCache<> cache;
 
@@ -80,6 +84,18 @@ class Module {
             .sharedMemorySize = sharedMemorySize,
             .key = Template(key).instantiate(templateArguments...),
         }});
+
+        return Result::SUCCESS;
+    }
+
+    Result compileKernel(const std::string& name,
+                     const Stream& stream) {
+        const auto& kernel = kernels[name];
+        BL_DEBUG("Compiling {}, {}", name, kernel.key);
+
+        cache
+            .get_kernel(kernel.key)
+            ->configure(kernel.gridSize, kernel.blockSize, kernel.sharedMemorySize, stream);
 
         return Result::SUCCESS;
     }

--- a/include/blade/modules/caster.hh
+++ b/include/blade/modules/caster.hh
@@ -54,6 +54,7 @@ class BLADE_API Caster : public Module {
 
     explicit Caster(const Config& config, const Input& input, const Stream& stream = {});
     Result process(const U64& currentStepCount, const Stream& stream = {}) final;
+    Result compile(const Stream& stream = {}) final;
 
  private:
     // Variables

--- a/include/blade/modules/channelizer/base.hh
+++ b/include/blade/modules/channelizer/base.hh
@@ -59,6 +59,7 @@ class BLADE_API Channelizer : public Module {
 
     explicit Channelizer(const Config& config, const Input& input, const Stream& stream = {});
     Result process(const U64& currentStepCount, const Stream& stream = {}) final;
+    Result compile(const Stream& stream = {}) final;
     ~Channelizer();
 
  private:

--- a/include/blade/modules/duplicator.hh
+++ b/include/blade/modules/duplicator.hh
@@ -54,6 +54,7 @@ class BLADE_API Duplicator : public Module {
 
     explicit Duplicator(const Config& config, const Input& input, const Stream& stream = {});
     Result process(const U64& currentStepCount, const Stream& stream = {}) final;
+    Result compile(const Stream& stream = {}) final;
 
  private:
     // Variables

--- a/include/blade/modules/phasor/generic.hh
+++ b/include/blade/modules/phasor/generic.hh
@@ -81,6 +81,9 @@ class BLADE_API Generic : public Module {
     explicit Generic(const Config& config, const Input& input, const Stream& stream = {});
     virtual ~Generic() = default;
     virtual Result process(const U64& currentComputeCount, const Stream& stream = {}) = 0;
+    virtual Result compile(const Stream& stream = {}) {
+        return Result::SUCCESS;
+    };
 
  protected:
     // Variables

--- a/include/blade/modules/polarizer.hh
+++ b/include/blade/modules/polarizer.hh
@@ -58,6 +58,7 @@ class BLADE_API Polarizer : public Module {
 
     explicit Polarizer(const Config& config, const Input& input, const Stream& stream = {});
     Result process(const U64& currentStepCount, const Stream& stream = {}) final;
+    Result compile(const Stream& stream = {}) final;
 
  private:
     // Variables

--- a/include/blade/modules/stacker.hh
+++ b/include/blade/modules/stacker.hh
@@ -66,6 +66,7 @@ class BLADE_API Stacker : public Module {
 
     explicit Stacker(const Config& config, const Input& input, const Stream& stream = {});
     Result process(const U64& currentStepCount, const Stream& stream = {}) final;
+    Result compile(const Stream& stream = {}) final;
 
  private:
     // Variables

--- a/include/blade/pipeline.hh
+++ b/include/blade/pipeline.hh
@@ -63,6 +63,7 @@ class BLADE_API Pipeline {
 
     void addModule(const std::shared_ptr<Module>& module);
 
+    Result compile(const U64& index);
     Result compute(const U64& index);
     Result synchronize(const U64& index);
     Result record(const U64& index);

--- a/include/blade/pipeline.hh
+++ b/include/blade/pipeline.hh
@@ -63,7 +63,7 @@ class BLADE_API Pipeline {
 
     void addModule(const std::shared_ptr<Module>& module);
 
-    Result compile(const U64& index);
+    Result compile(const U64& index = 0);
     Result compute(const U64& index);
     Result synchronize(const U64& index);
     Result record(const U64& index);

--- a/src/modules/caster/base.cc
+++ b/src/modules/caster/base.cc
@@ -58,6 +58,15 @@ Caster<IT, OT>::Caster(const Config& config,
 }
 
 template<typename IT, typename OT>
+Result Caster<IT, OT>::compile(const Stream& stream) {
+    if constexpr (std::is_same<IT, OT>::value) {
+        return Result::SUCCESS;
+    }
+    BL_DEBUG("Compiling ... Type: {} -> {}", TypeInfo<IT>::name, TypeInfo<OT>::name);
+    return this->compileKernel("main", stream);
+}
+
+template<typename IT, typename OT>
 Result Caster<IT, OT>::process(const U64& currentStepCount, const Stream& stream) {
     if constexpr (std::is_same<IT, OT>::value) {
         return Result::SUCCESS;

--- a/src/modules/channelizer/base.cc
+++ b/src/modules/channelizer/base.cc
@@ -128,6 +128,7 @@ Result Channelizer<IT, OT>::compile(const Stream& stream) {
 
     BL_DEBUG("Compiling FFT Size: {}", config.rate);
     BL_CHECK(this->compileKernel("main", stream));
+    return Result::SUCCESS;
 }
 
 template<typename IT, typename OT>

--- a/src/modules/channelizer/base.cc
+++ b/src/modules/channelizer/base.cc
@@ -121,6 +121,16 @@ Channelizer<IT, OT>::~Channelizer() {
 }
 
 template<typename IT, typename OT>
+Result Channelizer<IT, OT>::compile(const Stream& stream) {
+    if (config.rate == 1) {
+        return Result::SUCCESS;
+    }
+
+    BL_DEBUG("Compiling FFT Size: {}", config.rate);
+    BL_CHECK(this->compileKernel("main", stream));
+}
+
+template<typename IT, typename OT>
 Result Channelizer<IT, OT>::process(const U64& currentStepCount, const Stream& stream) {
     if (config.rate == 1) {
         return Result::SUCCESS;

--- a/src/modules/duplicator/base.cc
+++ b/src/modules/duplicator/base.cc
@@ -32,6 +32,11 @@ Duplicator<IT, OT>::Duplicator(const Config& config,
 }
 
 template<typename IT, typename OT>
+Result Duplicator<IT, OT>::compile(const Stream& stream) {
+    return Result::SUCCESS;
+}
+
+template<typename IT, typename OT>
 Result Duplicator<IT, OT>::process(const U64& currentStepCount, const Stream& stream) {
     return Blade::Copy(output.buf, input.buf, stream);
 }

--- a/src/modules/polarizer/base.cc
+++ b/src/modules/polarizer/base.cc
@@ -112,6 +112,15 @@ Polarizer<IT, OT>::Polarizer(const Config& config,
 }
 
 template<typename IT, typename OT>
+Result Polarizer<IT, OT>::compile(const Stream& stream) {
+    if (config.inputPolarization == config.outputPolarization) {
+        return Result::SUCCESS;
+    }
+
+    return this->compileKernel("main", stream);
+}
+
+template<typename IT, typename OT>
 Result Polarizer<IT, OT>::process(const U64& currentStepCount, const Stream& stream) {
     if (config.inputPolarization == config.outputPolarization) {
         return Result::SUCCESS;

--- a/src/modules/stacker/base.cc
+++ b/src/modules/stacker/base.cc
@@ -73,6 +73,31 @@ Stacker<IT, OT>::Stacker(const Config& config,
 }
 
 template<typename IT, typename OT>
+Result Stacker<IT, OT>::compile(const Stream& stream) {
+    if (config.multiplier == 1) {
+        return Result::SUCCESS;
+    }
+
+    if (strategy == Strategy::Kernel) {
+        cache
+            .get_kernel(
+                Template("stacker")
+                    .instantiate(TypeInfo<IT>::name)
+            )
+            ->configure(
+                PadGridSize(input.buf.size(), config.blockSize),
+                config.blockSize,
+                0,
+                stream
+            );
+    }
+
+    if (strategy == Strategy::Copy) {   }
+
+    return Result::SUCCESS;
+}
+
+template<typename IT, typename OT>
 Result Stacker<IT, OT>::process(const U64& currentStepCount, const Stream& stream) {
     if (config.multiplier == 1) {
         return Result::SUCCESS;

--- a/src/pipeline.cc
+++ b/src/pipeline.cc
@@ -166,4 +166,15 @@ Result Pipeline::compute(const U64& index) {
     return Result::SUCCESS;
 }
 
+Result Pipeline::compile(const U64& index) {
+    for (auto& module : _modules) {
+        const auto& result = module->compile(_streams[index]);
+        if (result != Result::SUCCESS) {
+            BL_FATAL("Module compilation failed: {}", module->name());
+            return result;
+        }
+    }
+    return Result::SUCCESS;
+}
+
 }  // namespace Blade


### PR DESCRIPTION
The first enqueue of a pipline has a relatively massive elapsed time. I think that this is due to the kernel compilations as commenting out the `compute()` call in the `Runner::enqueue()` mitigates this outlier.

I'd like to be able to manually cause compilation ahead of real-time sensitive processing, eg. see the addition to `benchmarks/bundles/generic/mode-x/mode_x.hh`.