### PR TITLE
Integrator axis configuration

### DIFF
--- a/include/blade/modules/integrator.hh
+++ b/include/blade/modules/integrator.hh
@@ -12,8 +12,9 @@ class BLADE_API Integrator : public Module {
     // Configuration
 
     struct Config {
-        U64 size = 1;  // Number of time samples to integrate within one block.
+        U64 size = 1;  // Number of indices to integrate within one block.
         U64 rate = 1;  // Number of blocks to integrate together.
+        U64 axis = 2;  // The block axis to integrate on, defaulting to T
 
         U64 blockSize = 512;
     };
@@ -62,6 +63,7 @@ class BLADE_API Integrator : public Module {
 
     explicit Integrator(const Config& config, const Input& input, const Stream& stream = {});
     Result process(const U64& currentStepCount, const Stream& stream = {}) final;
+    Result compile(const Stream& stream = {}) final;
 
  private:
     // Variables
@@ -73,14 +75,9 @@ class BLADE_API Integrator : public Module {
     U64 computeRatio;
 
     const ArrayShape getOutputBufferShape() const {
-        const auto& in = getInputBuffer().shape();
-
-        return ArrayShape({
-            static_cast<U64>(in.numberOfAspects()),
-            static_cast<U64>(in.numberOfFrequencyChannels()),
-            static_cast<U64>(in.numberOfTimeSamples() / config.size),
-            static_cast<U64>(in.numberOfPolarizations()),
-        });
+        ArrayShape::Type shape = getInputBuffer().shape();
+        shape[config.axis] /= config.size;
+        return shape;
     }
 };
 

--- a/python/blade/ext_integrator.cc
+++ b/python/blade/ext_integrator.cc
@@ -20,8 +20,10 @@ void NB_SUBMODULE(auto& m, const auto& in_name, const auto& out_name) {
     nb::class_<typename Class::Config>(mod, "config")
         .def(nb::init<const U64&,
                       const U64&,
+                      const U64&,
                       const U64&>(), "size"_a,
                                      "rate"_a,
+                                     "axis"_a = 2,
                                      "block_size"_a = 512);
 
     nb::class_<typename Class::Input>(mod, "input")

--- a/src/modules/integrator/base.cc
+++ b/src/modules/integrator/base.cc
@@ -23,37 +23,49 @@ Integrator<IT, OT>::Integrator(const Config& config,
         BL_CHECK_THROW(Result::ERROR);
     }
 
-    if ((input.buf.shape().numberOfTimeSamples() % config.size) != 0) {
-        BL_FATAL("Input number of time samples ({}) is not divisible by the integration size ({}).",
-                 input.buf.shape().numberOfTimeSamples(), config.size);
+    if ((input.buf.shape()[config.axis] % config.size) != 0) {
+        BL_FATAL("Input dimension #{} (length of {}) is not divisible by the integration size ({}).",
+                 config.axis, input.buf.shape()[config.axis], config.size);
         BL_CHECK_THROW(Result::ERROR);
     }
 
-    // Configure kernel instantiation.
-    BL_CHECK_THROW(
-        this->createKernel(
-            // Kernel name.
-            "main",
-            // Kernel function key.
-            "integrator",
-            // Kernel grid & block size.
-            PadGridSize(
-                getInputBuffer().size() / getInputBuffer().shape().numberOfPolarizations() / config.size,
-                config.blockSize
-            ),
-            config.blockSize,
-            0,
-            // Kernel templates.
-            TypeInfo<IT>::name,
-            TypeInfo<OT>::name,
-            config.size,
-            getInputBuffer().shape().numberOfPolarizations(),
-            getInputBuffer().size() / getInputBuffer().shape().numberOfPolarizations() / config.size
-        )
-    );
+    if (config.size == 1 && config.rate == 1) {
+        BL_INFO("Bypassing integration because size and rate are 1.");
+        BL_CHECK_THROW(Link(output.buf, input.buf));
+    }
+    else {
+        U64 integratedElementCount = 1;
+        for (int i = config.axis+1; i < 4; i++) {
+            integratedElementCount *= input.buf.shape()[i]; 
+        }
+    
+        // Configure kernel instantiation.
+        BL_CHECK_THROW(
+            this->createKernel(
+                // Kernel name.
+                "main",
+                // Kernel function key.
+                "integrator",
+                // Kernel grid & block size.
+                PadGridSize(
+                    getInputBuffer().size() / integratedElementCount / config.size,
+                    config.blockSize
+                ),
+                config.blockSize,
+                0,
+                // Kernel templates.
+                TypeInfo<IT>::name,
+                TypeInfo<OT>::name,
+                config.size,
+                integratedElementCount,
+                getInputBuffer().size() / integratedElementCount / config.size
+            )
+        );
+    
+        // Allocate output buffers.
+        output.buf = ArrayTensor<Device::CUDA, OT>(getOutputBufferShape());
+    }
 
-    // Allocate output buffers.
-    output.buf = ArrayTensor<Device::CUDA, OT>(getOutputBufferShape());
 
     // Print configuration values.
 
@@ -62,10 +74,25 @@ Integrator<IT, OT>::Integrator(const Config& config,
                                getOutputBuffer().shape());
     BL_INFO("Size: {}", config.size);
     BL_INFO("Rate: {}", config.rate);
+    BL_INFO("Axis: {}", config.axis);
+}
+
+template<typename IT, typename OT>
+Result Integrator<IT, OT>::compile(const Stream& stream) {
+    if (config.size == 1 && config.rate == 1) {
+        return Result::SUCCESS;
+    }
+    BL_DEBUG("Compiling Integrator Axis {}, Size: {}", config.axis, config.size);
+    BL_CHECK(this->compileKernel("main", stream));
+    return Result::SUCCESS;
 }
 
 template<typename IT, typename OT>
 Result Integrator<IT, OT>::process(const U64& currentStepCount, const Stream& stream) {
+    if (config.size == 1 && config.rate == 1) {
+        return Result::SUCCESS;
+    }
+
     if (currentStepCount == 0) {
         cudaMemsetAsync(output.buf.data(), 0, output.buf.size_bytes(), stream);
     }

--- a/src/modules/integrator/integrator.cu
+++ b/src/modules/integrator/integrator.cu
@@ -2,22 +2,22 @@
 
 using namespace Blade;
 
-template<typename IT, typename OT, U64 integrationSize, U64 numberOfPolarizations, U64 numberOfElements>
+template<typename IT, typename OT, U64 integrationSize, U64 numberOfIntegratedElements, U64 numberOfElements>
 __global__ void integrator(const ArrayTensor<Device::CUDA, IT> input,
                                  ArrayTensor<Device::CUDA, OT> output) {
     const U64 tid = (blockIdx.x * blockDim.x + threadIdx.x);
 
     if (tid < numberOfElements) {
-        OT accumulator[numberOfPolarizations] = {};
+        OT accumulator[numberOfIntegratedElements] = {};
 
         for (U64 i = 0; i < integrationSize; i++) {
-            for (U64 j = 0; j < numberOfPolarizations; j++) {
-                accumulator[j] += input[(tid * integrationSize * numberOfPolarizations) + (i * numberOfPolarizations) + j];
+            for (U64 j = 0; j < numberOfIntegratedElements; j++) {
+                accumulator[j] += input[(tid * integrationSize * numberOfIntegratedElements) + (i * numberOfIntegratedElements) + j];
             }
         }
 
-        for (U64 j = 0; j < numberOfPolarizations; j++) {
-            output[(tid * numberOfPolarizations) + j] += accumulator[j];
+        for (U64 j = 0; j < numberOfIntegratedElements; j++) {
+            output[(tid * numberOfIntegratedElements) + j] += accumulator[j];
         }
     }
 }

--- a/tests/modules/integrator/integrator.py
+++ b/tests/modules/integrator/integrator.py
@@ -18,13 +18,18 @@ class Pipeline:
         self.copy(buf, self.output.buf)
 
 
-def test(A, F, T, P, Size, Rate):
+def test(A, F, T, P, Size, Rate, Axis=2):
     in_shape = (A, F, T, P)
-    out_shape = (A, F, int(T / Size), P)
+
+    out_shape = tuple(
+        d if di != Axis else int(d / Size)
+        for di, d in enumerate(in_shape)
+    )
 
     config = {
         "size": Size,
         "rate": Rate,
+        "axis": Axis,
     }
 
     host_input = bl.array_tensor(in_shape, dtype=bl.cf32, device=bl.cpu)
@@ -49,8 +54,12 @@ def test(A, F, T, P, Size, Rate):
     #
 
     py_output = np.zeros(out_shape, dtype=np.complex64)
+    re_shape = [in_shape[i] for i in range(Axis)]
+    re_shape.extend([int(in_shape[Axis] / Size), Size])
+    re_shape.extend([in_shape[i] for i in range(Axis+1, len(in_shape))])
+    re_shape = tuple(re_shape) 
     for _ in range(Rate):
-        py_output += np.sum(np.reshape(bl_input, (A, F, int(T / Size), Size, P)), axis=3)
+        py_output += np.sum(np.reshape(bl_input, re_shape), axis=Axis+1)
 
     #
     # Compare Results
@@ -66,4 +75,6 @@ if __name__ == "__main__":
          int(sys.argv[3]),
          int(sys.argv[4]),
          int(sys.argv[5]),
-         int(sys.argv[6]))
+         int(sys.argv[6]),
+         int(sys.argv[7])
+         )

--- a/tests/modules/integrator/meson.build
+++ b/tests/modules/integrator/meson.build
@@ -3,7 +3,7 @@ if cfg_lst.get('BLADE_MODULE_INTEGRATOR', false)
         test(
             'test-modules-integrator-large',
             py,
-            args: [files('integrator.py'), '2', '1572864', '1', '2', '1', '16'],
+            args: [files('integrator.py'), '2', '1572864', '1', '2', '1', '16', '2'],
             is_parallel: false,
             timeout: 0,
             env: 'PYTHONPATH=@0@'.format(py_build_path),
@@ -11,7 +11,23 @@ if cfg_lst.get('BLADE_MODULE_INTEGRATOR', false)
         test(
             'test-modules-integrator-large-multi-time',
             py,
-            args: [files('integrator.py'), '2', '1572864', '128', '2', '16', '16'],
+            args: [files('integrator.py'), '2', '1572864', '128', '2', '16', '16', '2'],
+            is_parallel: false,
+            timeout: 0,
+            env: 'PYTHONPATH=@0@'.format(py_build_path),
+        )
+        test(
+            'test-modules-integrator-large-frequency',
+            py,
+            args: [files('integrator.py'), '2', '32768', '1', '2', '1024', '4', '1'],
+            is_parallel: false,
+            timeout: 0,
+            env: 'PYTHONPATH=@0@'.format(py_build_path),
+        )
+        test(
+            'test-modules-integrator-bypass',
+            py,
+            args: [files('integrator.py'), '2', '32768', '1', '2', '1', '1', '1'],
             is_parallel: false,
             timeout: 0,
             env: 'PYTHONPATH=@0@'.format(py_build_path),


### PR DESCRIPTION
Enable integrator to operate on axes other than just T.

Tests updated and passing, default `axis=2` so should be backwards compatible.