### PR TITLE
Mode X: ATA Augments

### DIFF
--- a/benchmarks/bundles/generic/mode-x/mode_x.hh
+++ b/benchmarks/bundles/generic/mode-x/mode_x.hh
@@ -49,19 +49,19 @@ class BenchmarkRunner {
     BenchmarkRunner() {
         BL_DEBUG("Configuring Pipeline.");
         config = {
-            .inputShape = ArrayShape({ 28, 192, 8192, 2 }),
-            .outputShape = ArrayShape({ 406, 192, 1, 4 }),
+            .inputShape = ArrayShape({ 28, 1, 65536, 2 }),
+            .outputShape = ArrayShape({ 406, 65536, 1, 4 }),
 
             .preChannelizerStackerMultiplier = 1,
 
-            .channelizerBypass = true,
+            .channelizerBypass = false,
 
-            .preCorrelatorStackerMultiplier = 1,
+            .preCorrelatorStackerMultiplier = 8,
 
-            .correlatorIntegrationRate = 1,
-            .correlatorUseSharedMemory = true,
+            .correlatorIntegrationRate = 128,
+            .correlatorUseSharedMemory = false,
             .correlatorCalculationMode = CALC_MODE::INTEGER,
-            .correlatorBlockSize = 64,
+            .correlatorBlockSize = 8,
         };
         pipeline = std::make_shared<Benchmark<IT, OT>>(config);
 

--- a/include/blade/bundles/generic/mode_x.hh
+++ b/include/blade/bundles/generic/mode_x.hh
@@ -58,11 +58,7 @@ class BLADE_API ModeX : public Bundle {
     // Output
 
     constexpr const ArrayTensor<Device::CUDA, OT>& getOutputBuffer() {
-        if (config.channelizerBypass) {
-            return bypassCorrelator->getOutputBuffer();
-        } else {
-            return correlator->getOutputBuffer();
-        }
+        return postCorrelatorFrequencyIntegrator->getOutputBuffer();
     }
 
     // Constructor
@@ -151,7 +147,7 @@ class BLADE_API ModeX : public Bundle {
 
             .blockSize = config.stackerBlockSize,
         }, {
-            .buf = channelizer->getOutputBuffer(),
+            .buf = correlator->getOutputBuffer(),
         });
 
         if (getOutputBuffer().shape() != config.outputShape) {

--- a/include/blade/bundles/generic/mode_x.hh
+++ b/include/blade/bundles/generic/mode_x.hh
@@ -9,6 +9,7 @@
 #include "blade/modules/caster.hh"
 #include "blade/modules/channelizer/base.hh"
 #include "blade/modules/correlator.hh"
+#include "blade/modules/integrator.hh"
 
 namespace Blade::Bundles::Generic {
 
@@ -31,6 +32,8 @@ class BLADE_API ModeX : public Bundle {
         U64 correlatorConjugateAntennaIndex = 1;
         bool correlatorUseSharedMemory = false;
         CALC_MODE correlatorCalculationMode = CALC_MODE::DOUBLE_PRECISION_FP;
+
+        U64 postCorrelatorFrequencyIntegrationRate = 1;
 
         U64 stackerBlockSize = 512;
         U64 casterBlockSize = 512;
@@ -141,6 +144,16 @@ class BLADE_API ModeX : public Bundle {
             });
         }
 
+        BL_DEBUG("Instantiating post-correlator frequency-integration module.");
+        this->connect(postCorrelatorFrequencyIntegrator, {
+            .size = config.postCorrelatorFrequencyIntegrationRate,
+            .axis = 1, // F
+
+            .blockSize = config.stackerBlockSize,
+        }, {
+            .buf = channelizer->getOutputBuffer(),
+        });
+
         if (getOutputBuffer().shape() != config.outputShape) {
             BL_FATAL("Expected output buffer size ({}) mismatch with actual size ({}).",
                      config.outputShape, getOutputBuffer().shape());
@@ -172,6 +185,9 @@ class BLADE_API ModeX : public Bundle {
 
     using BypassCorrelator = typename Modules::Correlator<IT, CF32>;
     std::shared_ptr<BypassCorrelator> bypassCorrelator;
+
+    using CorrelatorIntegrator = typename Modules::Integrator<CF32, CF32>;
+    std::shared_ptr<CorrelatorIntegrator> postCorrelatorFrequencyIntegrator;
 };
 
 }  // namespace Blade::Bundles::Generic

--- a/python/blade/ext_modex.cc
+++ b/python/blade/ext_modex.cc
@@ -34,6 +34,8 @@ void NB_SUBMODULE(auto& m, const auto& in_name, const auto& out_name) {
                       const CALC_MODE&,
 
                       const U64&,
+
+                      const U64&,
                       const U64&,
                       const U64&,
                       const U64&>(),
@@ -50,6 +52,8 @@ void NB_SUBMODULE(auto& m, const auto& in_name, const auto& out_name) {
                                      "correlator_conjugate_antenna_index"_a,
                                      "correlator_use_shared_memory"_a,
                                      "correlator_calculation_mode"_a,
+
+                                     "post_correlator_frequency_integration_rate"_a = 1,
 
                                      "stacker_block_size"_a = 512,
                                      "caster_block_size"_a = 512,


### PR DESCRIPTION
These additions to the Mode-X bundle support real-time efforts for the ATA's spectral-line observation modes.

Depends on PR#81.