### PR TITLE
chore(version): update CyberEther to v1.9.0

### DIFF
--- a/.github/workflows/cep.yml
+++ b/.github/workflows/cep.yml
@@ -16,19 +16,19 @@ jobs:
         include:
           - tag: x86_64-cuda
             runner: ubuntu-latest
-            base: ghcr.io/luigifcruz/cyberether:v1.8.2-ubuntu24-x86_64-cuda
+            base: ghcr.io/luigifcruz/cyberether:v1.9.0-ubuntu24-x86_64-cuda
             device: cuda
           - tag: aarch64-cuda
             runner: ubuntu-24.04-arm
-            base: ghcr.io/luigifcruz/cyberether:v1.8.2-ubuntu24-aarch64-cuda
+            base: ghcr.io/luigifcruz/cyberether:v1.9.0-ubuntu24-aarch64-cuda
             device: cuda
           - tag: x86_64-cpu
             runner: ubuntu-latest
-            base: ghcr.io/luigifcruz/cyberether:v1.8.2-ubuntu24-x86_64
+            base: ghcr.io/luigifcruz/cyberether:v1.9.0-ubuntu24-x86_64
             device: cpu
           - tag: aarch64-cpu
             runner: ubuntu-24.04-arm
-            base: ghcr.io/luigifcruz/cyberether:v1.8.2-ubuntu24-aarch64
+            base: ghcr.io/luigifcruz/cyberether:v1.9.0-ubuntu24-aarch64
             device: cpu
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,3 +26,4 @@ jobs:
         uses: softprops/action-gh-release@v2.6.2
         with:
           files: .dist/artifacts/*.cep
+          generate_release_notes: true

--- a/meson.build
+++ b/meson.build
@@ -21,7 +21,7 @@ if not plugin_is_linux
     error('BLADE only supports Linux targets for now.')
 endif
 
-minimum_jetstream_version = '1.8.0'
+minimum_jetstream_version = '1.9.0'
 
 #
 # Load Python

--- a/subprojects/cyberether.wrap
+++ b/subprojects/cyberether.wrap
@@ -1,7 +1,7 @@
 [wrap-git]
 directory = cyberether
 url = https://github.com/luigifcruz/cyberether.git
-revision = v1.8.2
+revision = v1.9.0
 depth = 1
 clone-recursive = true
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Bump BLADE to CyberEther v1.9.0 and cut `v2.0.0-beta6`.

## CyberEther v1.9.0
- Pin `subprojects/cyberether.wrap` to `v1.9.0`
- Build CEP artifacts from `ghcr.io/luigifcruz/cyberether:v1.9.0-ubuntu24-*`
- Raise `minimum_jetstream_version` to `1.9.0` (matches the CyberEther 1.9 plugin blueprint)

## Release
Tagging this commit as `v2.0.0-beta6`. The Release workflow will publish the GitHub release with auto-generated notes and attach the merged CEP bundle.

Please merge with a merge commit or fast-forward (not squash) so the release tag stays on `v2.0`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-16447a7c-cba7-4ecb-a184-362c51a0153e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-16447a7c-cba7-4ecb-a184-362c51a0153e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

