### PR TITLE
chore(version): cut v2.0.0-beta7 with static erfa

### DIFF
--- a/.github/workflows/cep.yml
+++ b/.github/workflows/cep.yml
@@ -51,7 +51,10 @@ jobs:
               trap '\''chown -R "${workspace_owner}" /workspace/.dist /workspace/build /workspace/subprojects 2>/dev/null || true'\'' EXIT
               git config --global --add safe.directory /workspace
               rm -rf build
-              meson setup build -Dbuildtype="${BUILD_TYPE}" -Ddevices="${BLADE_DEVICES}"
+              meson setup build \
+                --force-fallback-for=erfa \
+                -Dbuildtype="${BUILD_TYPE}" \
+                -Ddevices="${BLADE_DEVICES}"
               meson compile -C build blade_cep
               mkdir -p "${CEP_OUTPUT_DIR}"
               cp build/blade.cep "${CEP_OUTPUT_DIR}/blade.cep"

--- a/subprojects/radiointerferometryc99.wrap
+++ b/subprojects/radiointerferometryc99.wrap
@@ -1,9 +1,9 @@
 [wrap-git]
 directory = radiointerferometryc99
 url = https://github.com/MydonSolutions/radiointerferometryc99.git
-revision = master
+revision = f8f7aa8ca2b9ba13a958c23f21a0faf04cc93ebc
 depth = 1
 clone-recursive = false
 
 [provide]
-radiointerferometry = lib_radiointerferometry_dep 
+radiointerferometry = lib_radiointerferometry_dep


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Pin radiointerferometryc99 to the merged static-erfa commit and cut `v2.0.0-beta7` so the CEP plugin no longer dynamically links `liberfa`.

## Why
[MydonSolutions/radiointerferometryc99#2](https://github.com/MydonSolutions/radiointerferometryc99/pull/2) now builds ERFA as a static wrap when `default_library=static`. BLADE already requests that, but the wrap was still floating on `master`, so CEP builds could keep pulling a shared `liberfa.so`.

## Changes
- Pin `subprojects/radiointerferometryc99.wrap` to `f8f7aa8` (static erfa merge)
- Pass `--force-fallback-for=erfa` in the CEP Meson setup so the bundled wrap is used even if a system ERFA appears later

## Release
[`v2.0.0-beta7`](https://github.com/luigifcruz/blade/releases/tag/v2.0.0-beta7) is published with auto-generated notes and the rebuilt `blade.cep` attached. Merge this with a merge commit or fast-forward (not squash) so the release tag stays on `v2.0`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a01e31-a0ca-7d0c-b102-522780e063b4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a01e31-a0ca-7d0c-b102-522780e063b4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

